### PR TITLE
Compile and warning fixes for macOS

### DIFF
--- a/demo/MainWindow.h
+++ b/demo/MainWindow.h
@@ -45,7 +45,7 @@ class CMainWindow : public QMainWindow
 	Q_OBJECT
 private:
 	MainWindowPrivate* d;///< private data - pimpl
-	friend class MainWindowPrivate;
+	friend struct MainWindowPrivate;
 
 protected:
 	virtual void closeEvent(QCloseEvent* event) override;

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -3,17 +3,17 @@
 /*******************************************************************************
 ** Qt Advanced Docking System
 ** Copyright (C) 2017 Uwe Kindler
-** 
+**
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
 ** License as published by the Free Software Foundation; either
 ** version 2.1 of the License, or (at your option) any later version.
-** 
+**
 ** This library is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ** Lesser General Public License for more details.
-** 
+**
 ** You should have received a copy of the GNU Lesser General Public
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
@@ -52,7 +52,7 @@ class CDockAreaWidget : public QFrame
 	Q_OBJECT
 private:
 	DockAreaWidgetPrivate* d; ///< private data (pimpl)
-	friend class DockAreaWidgetPrivate;
+	friend struct DockAreaWidgetPrivate;
 
 private slots:
 	void onDockWidgetTitleClicked();

--- a/src/DockContainerWidget.h
+++ b/src/DockContainerWidget.h
@@ -3,17 +3,17 @@
 /*******************************************************************************
 ** Qt Advanced Docking System
 ** Copyright (C) 2017 Uwe Kindler
-** 
+**
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
 ** License as published by the Free Software Foundation; either
 ** version 2.1 of the License, or (at your option) any later version.
-** 
+**
 ** This library is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ** Lesser General Public License for more details.
-** 
+**
 ** You should have received a copy of the GNU Lesser General Public
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
@@ -54,7 +54,7 @@ class CDockContainerWidget : public QFrame
 	Q_OBJECT
 private:
 	DockContainerWidgetPrivate* d; ///< private data (pimpl)
-	friend class DockContainerWidgetPrivate;
+	friend struct DockContainerWidgetPrivate;
 
 protected:
 	/**

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -3,17 +3,17 @@
 /*******************************************************************************
 ** Qt Advanced Docking System
 ** Copyright (C) 2017 Uwe Kindler
-** 
+**
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
 ** License as published by the Free Software Foundation; either
 ** version 2.1 of the License, or (at your option) any later version.
-** 
+**
 ** This library is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ** Lesser General Public License for more details.
-** 
+**
 ** You should have received a copy of the GNU Lesser General Public
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
@@ -49,7 +49,7 @@ class CDockManager : public CDockContainerWidget
 	Q_OBJECT
 private:
 	DockManagerPrivate* d; ///< private data (pimpl)
-	friend class DockManagerPrivate;
+	friend struct DockManagerPrivate;
 
 protected:
 

--- a/src/DockOverlay.h
+++ b/src/DockOverlay.h
@@ -3,17 +3,17 @@
 /*******************************************************************************
 ** Qt Advanced Docking System
 ** Copyright (C) 2017 Uwe Kindler
-** 
+**
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
 ** License as published by the Free Software Foundation; either
 ** version 2.1 of the License, or (at your option) any later version.
-** 
+**
 ** This library is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ** Lesser General Public License for more details.
-** 
+**
 ** You should have received a copy of the GNU Lesser General Public
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
@@ -44,7 +44,7 @@ class CDockOverlay : public QFrame
 	Q_OBJECT
 private:
 	DockOverlayPrivate* d; //< private data class
-	friend class DockOverlayPrivate;
+	friend struct DockOverlayPrivate;
 	friend class DockOverlayCross;
 
 public:
@@ -118,7 +118,7 @@ class CDockOverlayCross : public QWidget
 	Q_OBJECT
 private:
 	DockOverlayCrossPrivate* d;
-	friend class DockOverlayCrossPrivate;
+	friend struct DockOverlayCrossPrivate;
 	friend class CDockOverlay;
 
 public:

--- a/src/DockSplitter.h
+++ b/src/DockSplitter.h
@@ -3,17 +3,17 @@
 /*******************************************************************************
 ** Qt Advanced Docking System
 ** Copyright (C) 2017 Uwe Kindler
-** 
+**
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
 ** License as published by the Free Software Foundation; either
 ** version 2.1 of the License, or (at your option) any later version.
-** 
+**
 ** This library is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ** Lesser General Public License for more details.
-** 
+**
 ** You should have received a copy of the GNU Lesser General Public
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
@@ -43,7 +43,7 @@ class CDockSplitter : public QSplitter
 	Q_OBJECT
 private:
 	DockSplitterPrivate* d;
-	friend class DockSplitterPrivate;
+	friend struct DockSplitterPrivate;
 
 public:
 	CDockSplitter(QWidget *parent = Q_NULLPTR);

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -3,17 +3,17 @@
 /*******************************************************************************
 ** Qt Advanced Docking System
 ** Copyright (C) 2017 Uwe Kindler
-** 
+**
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
 ** License as published by the Free Software Foundation; either
 ** version 2.1 of the License, or (at your option) any later version.
-** 
+**
 ** This library is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ** Lesser General Public License for more details.
-** 
+**
 ** You should have received a copy of the GNU Lesser General Public
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
@@ -52,14 +52,14 @@ class CDockWidget : public QFrame
 	Q_OBJECT
 private:
 	DockWidgetPrivate* d; ///< private data (pimpl)
-	friend class DockWidgetPrivate;
+	friend struct DockWidgetPrivate;
 
 protected:
 	friend class CDockContainerWidget;
 	friend class CDockAreaWidget;
 	friend class CFloatingDockContainer;
 	friend class CDockManager;
-	friend class DockContainerWidgetPrivate;
+	friend struct DockContainerWidgetPrivate;
 
 	/**
 	 * Assigns the dock manager that manages this dock widget

--- a/src/DockWidgetTitleBar.h
+++ b/src/DockWidgetTitleBar.h
@@ -3,17 +3,17 @@
 /*******************************************************************************
 ** Qt Advanced Docking System
 ** Copyright (C) 2017 Uwe Kindler
-** 
+**
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
 ** License as published by the Free Software Foundation; either
 ** version 2.1 of the License, or (at your option) any later version.
-** 
+**
 ** This library is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ** Lesser General Public License for more details.
-** 
+**
 ** You should have received a copy of the GNU Lesser General Public
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
@@ -48,7 +48,7 @@ class CDockWidgetTitleBar : public QFrame
 
 private:
 	DockWidgetTitleBarPrivate* d; ///< private data (pimpl)
-	friend class DockWidgetTitleBarPrivate;
+	friend struct DockWidgetTitleBarPrivate;
 
 protected:
 	virtual void mousePressEvent(QMouseEvent* ev) override;

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -3,17 +3,17 @@
 /*******************************************************************************
 ** Qt Advanced Docking System
 ** Copyright (C) 2017 Uwe Kindler
-** 
+**
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
 ** License as published by the Free Software Foundation; either
 ** version 2.1 of the License, or (at your option) any later version.
-** 
+**
 ** This library is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ** Lesser General Public License for more details.
-** 
+**
 ** You should have received a copy of the GNU Lesser General Public
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
@@ -51,7 +51,7 @@ class CFloatingDockContainer : public QWidget
 	Q_OBJECT
 private:
 	FloatingDockContainerPrivate* d; ///< private data (pimpl)
-	friend class FloatingDockContainerPrivate;
+	friend struct FloatingDockContainerPrivate;
 
 private slots:
 	void onDockAreasAddedOrRemoved();

--- a/src/ads_globals.cpp
+++ b/src/ads_globals.cpp
@@ -1,17 +1,17 @@
 /*******************************************************************************
 ** Qt Advanced Docking System
 ** Copyright (C) 2017 Uwe Kindler
-** 
+**
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
 ** License as published by the Free Software Foundation; either
 ** version 2.1 of the License, or (at your option) any later version.
-** 
+**
 ** This library is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ** Lesser General Public License for more details.
-** 
+**
 ** You should have received a copy of the GNU Lesser General Public
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
@@ -62,12 +62,12 @@ CDockInsertParam dockAreaInsertParameters(DockWidgetArea Area)
 {
 	switch (Area)
     {
-	case TopDockWidgetArea: return QPair<Qt::Orientation, bool>(Qt::Vertical, false);
-	case RightDockWidgetArea: return QPair<Qt::Orientation, bool>(Qt::Horizontal, true);
+	case TopDockWidgetArea: return CDockInsertParam(Qt::Vertical, false);
+	case RightDockWidgetArea: return CDockInsertParam(Qt::Horizontal, true);
 	case CenterDockWidgetArea:
-	case BottomDockWidgetArea: return QPair<Qt::Orientation, bool>(Qt::Vertical, true);
-	case LeftDockWidgetArea: return QPair<Qt::Orientation, bool>(Qt::Horizontal, false);
-	default: QPair<Qt::Orientation, bool>(Qt::Vertical, false);
+	case BottomDockWidgetArea: return CDockInsertParam(Qt::Vertical, true);
+	case LeftDockWidgetArea: return CDockInsertParam(Qt::Horizontal, false);
+	default: CDockInsertParam(Qt::Vertical, false);
     } // switch (Area)
 
 	return CDockInsertParam(Qt::Vertical, false);


### PR DESCRIPTION
Number of warnings like this has been fixed

```
DockWidget.h:62:9: warning: class 'DockContainerWidgetPrivate' was previously declared as a struct [-Wmismatched-tags]
```

Also in `ads_globals.cpp` Clang didn’t like how that code setup so I changed it to what I think is the correct way. This would be good to get verified.