### PR TITLE
Fix of action leak in CDockWidget

### DIFF
--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -214,7 +214,7 @@ CDockWidget::CDockWidget(const QString &title, QWidget *parent) :
 	setObjectName(title);
 
 	d->TabWidget = new CDockWidgetTab(this);
-    d->ToggleViewAction = new QAction(title, nullptr);
+    d->ToggleViewAction = new QAction(title, this);
 	d->ToggleViewAction->setCheckable(true);
 	connect(d->ToggleViewAction, SIGNAL(triggered(bool)), this,
 		SLOT(toggleView(bool)));


### PR DESCRIPTION
When i figure out, how to delete widgets after closing tabs. I took gamma ray from kdab and started to monitor what happens when I open and close the tabs. At some point, I noticed that there are some dangling QActions. Fortunately, the problem was solved simply, when creating a new DockWidget, a QAction is created which is responsible for showing / hiding the tab, which was constructed with nullptr to parent, and the object was not deleted in the destructor. Therefore, this QAction remained in memory.