### PR TITLE
Add .idea folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ moc_*
 ui_*
 Makefile
 
+# IDEs
+.idea


### PR DESCRIPTION
All JetBrains IDEs create a .idea folder in the project root that is local to the system/user and should not be included in a repository.