### PR TITLE
Replace deprecated function call to QFontMetrics::width()

### DIFF
--- a/src/ElidingLabel.cpp
+++ b/src/ElidingLabel.cpp
@@ -157,7 +157,11 @@ QSize CElidingLabel::minimumSizeHint() const
         return QLabel::minimumSizeHint();
     }
     const QFontMetrics  &fm = fontMetrics();
-    QSize size(fm.width(d->Text.left(2) + "…"), fm.height());
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        QSize size(fm.horizontalAdvance(d->Text), QLabel::sizeHint().height());
+    #else
+        QSize size(fm.width(d->Text), QLabel::sizeHint().height());
+    #endif
     return size;
 }
 
@@ -170,7 +174,11 @@ QSize CElidingLabel::sizeHint() const
         return QLabel::sizeHint();
     }
     const QFontMetrics& fm = fontMetrics();
-    QSize size(fm.width(d->Text), QLabel::sizeHint().height());
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        QSize size(fm.horizontalAdvance(d->Text), QLabel::sizeHint().height());
+    #else
+        QSize size(fm.width(d->Text), QLabel::sizeHint().height());
+    #endif
 	return size;
 }
 


### PR DESCRIPTION
QFontMetrics::width() has been deprecated. Using QFontMetrics::horizontalAdvance() is the proper way to go (introduce in Qt 5.11).