### PR TITLE
fix: Add quotes to CMake BUILD_INTERFACE generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ install(TARGETS qtadvanceddocking
     ARCHIVE DESTINATION lib COMPONENT library
 )
 target_include_directories(qtadvanceddocking PUBLIC 
-    $<BUILD_INTERFACE:${ads_INCLUDE}>
+    "$<BUILD_INTERFACE:${ads_INCLUDE}>"
     $<INSTALL_INTERFACE:include>
     )
 target_link_libraries(qtadvanceddocking PUBLIC ${ads_LIBS})


### PR DESCRIPTION
I had trouble including this project as part of a bigger CMake build until the quotes were added. This is only an issue because `${ads_INCLUDE}` is a list. Relevant SO [answer](https://stackoverflow.com/a/44430690)

#46 