### PR TITLE
Allow disabling of internal stylesheet.

### DIFF
--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -396,7 +396,7 @@ void DockManagerPrivate::addActionToMenu(QAction* Action, QMenu* Menu, bool Inse
 
 
 //============================================================================
-CDockManager::CDockManager(QWidget *parent) :
+CDockManager::CDockManager(QWidget *parent, bool useInternalStyleSheet) :
 	CDockContainerWidget(this, parent),
 	d(new DockManagerPrivate(this))
 {
@@ -411,7 +411,10 @@ CDockManager::CDockManager(QWidget *parent) :
 	d->DockAreaOverlay = new CDockOverlay(this, CDockOverlay::ModeDockAreaOverlay);
 	d->ContainerOverlay = new CDockOverlay(this, CDockOverlay::ModeContainerOverlay);
 	d->Containers.append(this);
-	d->loadStylesheet();
+	if (useInternalStyleSheet)
+	{
+		d->loadStylesheet();
+	}
 }
 
 //============================================================================

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -130,10 +130,12 @@ public:
 	 * Default Constructor.
 	 * If the given parent is a QMainWindow, the dock manager sets itself as the
 	 * central widget.
+	 * Loading of the internal stylesheet can be skipped by setting
+	 * useInternalStyleSheet to false.
 	 * Before you create any dock widgets, you should properly setup the
 	 * configuration flags via setConfigFlags()
 	 */
-	CDockManager(QWidget* parent = 0);
+	CDockManager(QWidget* parent = 0, bool useInternalStyleSheet = true);
 
 	/**
 	 * Virtual Destructor


### PR DESCRIPTION
If we compile this library directly from the repo (i.e. the stylesheet is compiled in), we have issues with styling due to the fact that our entire stylesheet is loaded at application start - so this PR allows us to prevent the loading of the internal Qt-ADS stylesheet so it doesn't overwrite our own style.