### PR TITLE
CloseButton: Retain size when hidden.

### DIFF
--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -152,7 +152,10 @@ void DockWidgetTabPrivate::createLayout()
 	CloseIcon.addPixmap(internal::createTransparentPixmap(normalPixmap, 0.25), QIcon::Disabled);
 	CloseButton->setIcon(CloseIcon);
 
-    CloseButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+	CloseButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+	QSizePolicy spRetain = CloseButton->sizePolicy();
+	spRetain.setRetainSizeWhenHidden(true);
+	CloseButton->setSizePolicy(spRetain);
 	CloseButton->setVisible(false);
 	#ifndef QT_NO_TOOLTIP
 	CloseButton->setToolTip(QObject::tr("Close Tab"));


### PR DESCRIPTION
Prevents the tab widget from changing size when switching the active tab.

![animation](https://user-images.githubusercontent.com/1648285/64580791-3babbf80-d3ba-11e9-9575-0398db8f69d4.gif)

Tried to achieve this same behaviour by changing only the stylesheet using an appropriate margin, but it seems the margin value is not updated when changing the tab (even though we have the `polish`/`unpolish` calls to update the style on tab change).
