### PR TITLE
Update floating widget titlebar visibility after adding new tab

### DIFF
--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -916,6 +916,7 @@ CDockAreaWidget* DockContainerWidgetPrivate::dockWidgetIntoDockArea(DockWidgetAr
 	if (CenterDockWidgetArea == area)
 	{
 		TargetDockArea->addDockWidget(Dockwidget);
+		TargetDockArea->updateTitleBarVisibility();
 		return TargetDockArea;
 	}
 


### PR DESCRIPTION
When adding new DockWidget directly to a floating container using `addDockWidgetTabToArea`, the title bar is hidden until title bar is updated in some other way. This should cause title bar to always update.