### PR TITLE
Fix cmake when compiling to a static lib

### DIFF
--- a/src/ElidingLabel.cpp
+++ b/src/ElidingLabel.cpp
@@ -157,7 +157,11 @@ QSize CElidingLabel::minimumSizeHint() const
         return QLabel::minimumSizeHint();
     }
     const QFontMetrics  &fm = fontMetrics();
-    QSize size(fm.width(d->Text.left(2) + "…"), fm.height());
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        QSize size(fm.horizontalAdvance(d->Text), QLabel::sizeHint().height());
+    #else
+        QSize size(fm.width(d->Text), QLabel::sizeHint().height());
+    #endif
     return size;
 }
 
@@ -170,7 +174,11 @@ QSize CElidingLabel::sizeHint() const
         return QLabel::sizeHint();
     }
     const QFontMetrics& fm = fontMetrics();
-    QSize size(fm.width(d->Text), QLabel::sizeHint().height());
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        QSize size(fm.horizontalAdvance(d->Text), QLabel::sizeHint().height());
+    #else
+        QSize size(fm.width(d->Text), QLabel::sizeHint().height());
+    #endif
 	return size;
 }
 


### PR DESCRIPTION
`ADS_STATIC` and `ADS_SHARED_EXPORT` are used in the public API and must therefore be `PUBLIC`. Currently the `ADS_EXPORT` macro in `ads_globals.h` is set to `Q_DECL_IMPORT` instead of being empty which makes it impossible to link statically.