### PR TITLE
Fix import in QtAds.__init__.py

### DIFF
--- a/PyQtAds/QtAds/__init__.py
+++ b/PyQtAds/QtAds/__init__.py
@@ -1,5 +1,5 @@
 from .ads import ads
-from ._version import *
+from .._version import *
 
 import inspect
 


### PR DESCRIPTION
Without the fix, importing from the installed python module results in the following error:
```
>>> from PyQtAds.QtAds import CDockWidget                                                                                                                                                                                       
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-9ff2e5d03daf> in <module>
----> 1 from PyQtAds.QtAds import CDockWidget

~/tmp/Qt-Advanced-Docking-System/build/lib.linux-x86_64-3.8/PyQtAds/QtAds/__init__.py in <module>
      1 from .ads import ads
----> 2 from ._version import *
      3 
      4 import inspect
      5 

ModuleNotFoundError: No module named 'PyQtAds.QtAds._version'
```