### PR TITLE
Fix issue #88: floating widgets going to the background when moving them

### DIFF
--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -339,6 +339,7 @@ void CFloatingDockContainer::moveEvent(QMoveEvent *event)
 
 	case DraggingFloatingWidget:
 		d->updateDropOverlays(QCursor::pos());
+		QApplication::setActiveWindow(this);
 		break;
 	default:
 		break;


### PR DESCRIPTION
Fix for issue #88 .
In OSX when hiding the DockAreaOverlay the application would set the main window as the active window for some reason. This fixes that by resetting the active window to the floating widget after updating the overlays.

Fix tested in Windows and OSX.