### PR TITLE
Add visibilityChanged and featuresChanged signals to DockWidget

### DIFF
--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -288,6 +288,7 @@ void MainWindowPrivate::createContent()
 	for (auto DockWidget : DockManager->dockWidgetsMap())
 	{
 		_this->connect(DockWidget, SIGNAL(viewToggled(bool)), SLOT(onViewToggled(bool)));
+        _this->connect(DockWidget, SIGNAL(visibilityChanged(bool)), SLOT(onViewVisibilityChanged(bool)));
 	}
 }
 
@@ -485,5 +486,17 @@ void CMainWindow::createTable()
 	DockWidget->setFeature(ads::CDockWidget::DockWidgetDeleteOnClose, true);
 	auto FloatingWidget = d->DockManager->addDockWidgetFloating(DockWidget);
     FloatingWidget->move(QPoint(40, 40));
+}
+
+//============================================================================
+void CMainWindow::onViewVisibilityChanged(bool Open)
+{
+    auto DockWidget = qobject_cast<ads::CDockWidget*>(sender());
+    if (!DockWidget)
+    {
+        return;
+    }
+
+    qDebug() << DockWidget->objectName() << " visibilityChanged(" << Open << ")";
 }
 

--- a/demo/MainWindow.h
+++ b/demo/MainWindow.h
@@ -61,6 +61,7 @@ private slots:
 	void onViewToggled(bool Open);
 	void createEditor();
 	void createTable();
+    void onViewVisibilityChanged(bool Open);
 };
 
 #endif // MAINWINDOW_H

--- a/sip/DockWidget.sip
+++ b/sip/DockWidget.sip
@@ -97,6 +97,8 @@ signals:
 	void closed();
 	void titleChanged(const QString& Title);
 	void topLevelChanged(bool topLevel);
+    void visibilityChanged(bool visible);
+    void featuresChanged(ads::CDockWidget::DockWidgetFeatures features);
 };
 
 };

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -294,6 +294,7 @@ void CDockWidget::setFeatures(DockWidgetFeatures features)
 		return;
 	}
 	d->Features = features;
+    emit featuresChanged(d->Features);
 	d->TabWidget->onDockWidgetFeaturesChanged();
 }
 
@@ -450,7 +451,7 @@ void CDockWidget::toggleViewInternal(bool Open)
 	}
 	d->Closed = !Open;
 	d->ToggleViewAction->blockSignals(true);
-	d->ToggleViewAction->setChecked(Open);
+    d->ToggleViewAction->setChecked(Open);
 	d->ToggleViewAction->blockSignals(false);
 	if (d->DockArea)
 	{
@@ -515,23 +516,36 @@ void CDockWidget::flagAsUnassigned()
 //============================================================================
 bool CDockWidget::event(QEvent *e)
 {
-	if (e->type() == QEvent::WindowTitleChange)
-	{
-		const auto title = windowTitle();
-		if (d->TabWidget)
-		{
-			d->TabWidget->setText(title);
-		}
-		if (d->ToggleViewAction)
-		{
-			d->ToggleViewAction->setText(title);
-		}
-		if (d->DockArea)
-		{
-			d->DockArea->markTitleBarMenuOutdated();//update tabs menu
-		}
-		emit titleChanged(title);
-	}
+    switch (e->type())
+    {
+#ifndef QT_NO_ACTION
+        case QEvent::Hide:
+            emit visibilityChanged(false);
+            break;
+        case QEvent::Show:
+            emit visibilityChanged(geometry().right() >= 0 && geometry().bottom() >= 0);
+            break;
+#endif
+        case QEvent::WindowTitleChange: {
+            const auto title = windowTitle();
+            if (d->TabWidget)
+            {
+                d->TabWidget->setText(title);
+            }
+            if (d->ToggleViewAction)
+            {
+                d->ToggleViewAction->setText(title);
+            }
+            if (d->DockArea)
+            {
+                d->DockArea->markTitleBarMenuOutdated();//update tabs menu
+            }
+            emit titleChanged(title);
+            break;
+        }
+        default:
+            break;
+    }
 	return Super::event(e);
 }
 

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -449,6 +449,19 @@ signals:
 	 * otherwise it is false.
 	 */
 	void topLevelChanged(bool topLevel);
+
+    /**
+     * This signal is emitted when the dock widget becomes visible (or invisible).
+     * This happens when the widget is hidden or shown, as well as when it
+     * is docked in a tabbed dock area and its tab becomes selected or unselected.
+     */
+    void visibilityChanged(bool visible);
+
+    /**
+     * This signal is emitted when the features property changes.
+     * The features parameter gives the new value of the property.
+     */
+    void featuresChanged(DockWidgetFeatures features);
 }; // class DockWidget
 }
  // namespace ads


### PR DESCRIPTION
Add two new signals to DockWidget that are missing compared to QDockWidget:

- visibilityChanged: This signal is emitted when the dock widget becomes visible (or invisible). This happens when the widget is hidden or shown, as well as when it is docked in a tabbed dock area and its tab becomes selected or unselected.
- featuresChanged: This signal is emitted when the features property changes. The features parameter gives the new value of the property.