### PR TITLE
Fix tabs not being active when restoring state

### DIFF
--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -345,7 +345,7 @@ void CDockAreaTabBar::insertTab(int Index, CDockWidgetTab* Tab)
 	connect(Tab, SIGNAL(moved(const QPoint&)), this, SLOT(onTabWidgetMoved(const QPoint&)));
 	Tab->installEventFilter(this);
 	emit tabInserted(Index);
-	if (Index <= d->CurrentIndex)
+	if (Index <= d->CurrentIndex || d->CurrentIndex == -1)
 	{
 		setCurrentIndex(d->CurrentIndex + 1);
 	}


### PR DESCRIPTION
Regression introduced by 29ebc83b351932598ae83f47205c4d09bb852b47

