### PR TITLE
Fix of issue "setConfigFlag(DockAreaHasCloseButton, false) issue

### DIFF
--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -416,6 +416,8 @@ CMainWindow::CMainWindow(QWidget *parent) :
 	// not change if the visibility of the close button changes
     //CDockManager::setConfigFlag(CDockManager::RetainTabSizeWhenCloseButtonHidden, true);
 
+    // uncomment the following line if you don't want close button on DockArea's title bar
+    // CDockManager::setConfigFlag(CDockManager::DockAreaHasCloseButton, false);
 
 	// Now create the dock manager and its content
 	d->DockManager = new CDockManager(this);


### PR DESCRIPTION
this is the isolated change that only fixes mentioned issue (and only for DockAreaHasCloseButton)
I also added button pointer initialization with nullptr for other two buttons and deletion of all three in ~DockAreaTitleBarPrivate()