### PR TITLE
setAllowedAreas for individual DockAreaWidget

### DIFF
--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -276,7 +276,14 @@ void MainWindowPrivate::createContent()
 	QMenu* ViewMenu = ui.menuView;
 	auto DockWidget = createCalendarDockWidget(ViewMenu);
 	DockWidget->setFeature(ads::CDockWidget::DockWidgetClosable, false);
-	DockManager->addDockWidget(ads::LeftDockWidgetArea, DockWidget);
+	auto SpecialDockArea = DockManager->addDockWidget(ads::LeftDockWidgetArea, DockWidget);
+
+	// For this Special Dock Area we want to avoid dropping on the center of it (i.e. we don't want this widget to be ever tabbified):
+	{
+		SpecialDockArea->setAllowedAreas(ads::OuterDockAreas);
+		//SpecialDockArea->setAllowedAreas({ads::LeftDockWidgetArea, ads::RightDockWidgetArea}); // just for testing
+	}
+
 	DockManager->addDockWidget(ads::LeftDockWidgetArea, createLongTextLabelDockWidget(ViewMenu));
 	auto FileSystemWidget = createFileSystemTreeDockWidget(ViewMenu);
 	auto ToolBar = FileSystemWidget->createDefaultToolBar();

--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -245,6 +245,7 @@ struct DockAreaWidgetPrivate
 	CDockAreaTitleBar*	TitleBar		= nullptr;
 	CDockManager*		DockManager		= nullptr;
 	bool UpdateTitleBarButtons = false;
+  DockWidgetAreas     AllowedAreas = AllDockAreas;
 
 	/**
 	 * Private data constructor
@@ -812,6 +813,15 @@ void CDockAreaWidget::setVisible(bool Visible)
 	}
 }
 
+void CDockAreaWidget::setAllowedAreas(DockWidgetAreas areas)
+{
+    d->AllowedAreas = areas;
+}
+
+DockWidgetAreas CDockAreaWidget::allowedAreas() const
+{
+    return d->AllowedAreas;
+}
 
 //============================================================================
 QAbstractButton* CDockAreaWidget::titleBarButton(TitleBarButton which) const

--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -245,7 +245,7 @@ struct DockAreaWidgetPrivate
 	CDockAreaTitleBar*	TitleBar		= nullptr;
 	CDockManager*		DockManager		= nullptr;
 	bool UpdateTitleBarButtons = false;
-  DockWidgetAreas     AllowedAreas = AllDockAreas;
+	DockWidgetAreas		AllowedAreas	= AllDockAreas;
 
 	/**
 	 * Private data constructor
@@ -815,12 +815,12 @@ void CDockAreaWidget::setVisible(bool Visible)
 
 void CDockAreaWidget::setAllowedAreas(DockWidgetAreas areas)
 {
-    d->AllowedAreas = areas;
+	d->AllowedAreas = areas;
 }
 
 DockWidgetAreas CDockAreaWidget::allowedAreas() const
 {
-    return d->AllowedAreas;
+	return d->AllowedAreas;
 }
 
 //============================================================================

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -254,9 +254,15 @@ public:
 	 */
 	virtual void setVisible(bool Visible) override;
 
-    void setAllowedAreas(DockWidgetAreas areas);
+	/**
+	 * Configures the areas of this particular dock area that are allowed for docking
+	 */
+	void setAllowedAreas(DockWidgetAreas areas);
 
-    DockWidgetAreas allowedAreas() const;
+	/**
+	 * Returns flags with all allowed drop areas of this particular dock area
+	 */
+	DockWidgetAreas allowedAreas() const;
 
 public slots:
 	/**

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -254,6 +254,10 @@ public:
 	 */
 	virtual void setVisible(bool Visible) override;
 
+    void setAllowedAreas(DockWidgetAreas areas);
+
+    DockWidgetAreas allowedAreas() const;
+
 public slots:
 	/**
 	 * This activates the tab for the given tab index.

--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -334,7 +334,7 @@ eDropMode DockContainerWidgetPrivate::getDropMode(const QPoint& TargetPos)
 	if (DockArea)
 	{
 		auto dropOverlay = DockManager->dockAreaOverlay();
-		dropOverlay->setAllowedAreas(AllDockAreas);
+		dropOverlay->setAllowedAreas(DockArea->allowedAreas());
 		dropArea = dropOverlay->showOverlay(DockArea);
 		if (ContainerDropArea != InvalidDockWidgetArea &&
 			ContainerDropArea != dropArea)
@@ -1392,7 +1392,7 @@ void CDockContainerWidget::dropFloatingWidget(CFloatingDockContainer* FloatingWi
 	if (DockArea)
 	{
 		auto dropOverlay = d->DockManager->dockAreaOverlay();
-		dropOverlay->setAllowedAreas(AllDockAreas);
+		dropOverlay->setAllowedAreas(DockArea->allowedAreas());
 		dropArea = dropOverlay->showOverlay(DockArea);
 		if (ContainerDropArea != InvalidDockWidgetArea &&
 			ContainerDropArea != dropArea)
@@ -1447,7 +1447,7 @@ void CDockContainerWidget::dropWidget(QWidget* Widget, const QPoint& TargetPos)
 	if (DockArea)
 	{
 		auto dropOverlay = d->DockManager->dockAreaOverlay();
-		dropOverlay->setAllowedAreas(AllDockAreas);
+		dropOverlay->setAllowedAreas(DockArea->allowedAreas());
 		dropArea = dropOverlay->showOverlay(DockArea);
 		if (ContainerDropArea != InvalidDockWidgetArea &&
 			ContainerDropArea != dropArea)

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -207,7 +207,7 @@ void FloatingDockContainerPrivate::updateDropOverlays(const QPoint &GlobalPos)
 	{
 		DockAreaOverlay->enableDropPreview(true);
 		DockAreaOverlay->setAllowedAreas(
-		    (VisibleDockAreas == 1) ? NoDockWidgetArea : AllDockAreas);
+		    (VisibleDockAreas == 1) ? NoDockWidgetArea : DockArea->allowedAreas());
 		DockWidgetArea Area = DockAreaOverlay->showOverlay(DockArea);
 
 		// A CenterDockWidgetArea for the dockAreaOverlay() indicates that

--- a/src/FloatingDragPreview.cpp
+++ b/src/FloatingDragPreview.cpp
@@ -127,7 +127,7 @@ void FloatingDragPreviewPrivate::updateDropOverlays(const QPoint &GlobalPos)
 	{
 		DockAreaOverlay->enableDropPreview(true);
 		DockAreaOverlay->setAllowedAreas(
-		    (VisibleDockAreas == 1) ? NoDockWidgetArea : AllDockAreas);
+		    (VisibleDockAreas == 1) ? NoDockWidgetArea : DockArea->allowedAreas());
 		DockWidgetArea Area = DockAreaOverlay->showOverlay(DockArea);
 
 		// A CenterDockWidgetArea for the dockAreaOverlay() indicates that


### PR DESCRIPTION
Following issue https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/104
This change allows setting DockAreas per individual DockAreaWidget. By default, all areas are allowed to maintain backward compatibility.