### PR TITLE
Added DockAreaHideDisabledButtons configuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-This repository is the fork of [Advanced Docking System for Qt](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System) from Uwe Kindler, which is in turn fork of [Advanced Docking System for Qt](https://github.com/mfreiholz/Qt-Advanced-Docking-System) 
-from Manuel Freiholz.
-
-I use it to make minor customizations needed for my application(s) and make small contributions to the parent repository.
-
-Below is the content of README from the Uwe's repository (I will try to keep them in sync):
-
-
 # Advanced Docking System for Qt 
 [![Build Status](https://travis-ci.org/githubuser0xFFFF/Qt-Advanced-Docking-System.svg?branch=master)](https://travis-ci.org/githubuser0xFFFF/Qt-Advanced-Docking-System)
 [![Build status](https://ci.appveyor.com/api/projects/status/qcfb3cy932jw9mpy/branch/master?svg=true)](https://ci.appveyor.com/project/githubuser0xFFFF/qt-advanced-docking-system/branch/master)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+This repository is the fork of [Advanced Docking System for Qt](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System) from Uwe Kindler, which is in turn fork of [Advanced Docking System for Qt](https://github.com/mfreiholz/Qt-Advanced-Docking-System) 
+from Manuel Freiholz.
+
+I use it to make minor customizations needed for my application(s) and make small contributions to the parent repository.
+
+Below is the content of README from the Uwe's repository (I will try to keep them in sync):
+
+
 # Advanced Docking System for Qt 
 [![Build Status](https://travis-ci.org/githubuser0xFFFF/Qt-Advanced-Docking-System.svg?branch=master)](https://travis-ci.org/githubuser0xFFFF/Qt-Advanced-Docking-System)
 [![Build status](https://ci.appveyor.com/api/projects/status/qcfb3cy932jw9mpy/branch/master?svg=true)](https://ci.appveyor.com/project/githubuser0xFFFF/qt-advanced-docking-system/branch/master)

--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -276,6 +276,8 @@ void MainWindowPrivate::createContent()
 	QMenu* ViewMenu = ui.menuView;
 	auto DockWidget = createCalendarDockWidget(ViewMenu);
 	DockWidget->setFeature(ads::CDockWidget::DockWidgetClosable, false);
+	DockWidget->setFeature(ads::CDockWidget::DockWidgetMovable, false);
+	DockWidget->setFeature(ads::CDockWidget::DockWidgetFloatable, false);
 	auto SpecialDockArea = DockManager->addDockWidget(ads::LeftDockWidgetArea, DockWidget);
 
 	// For this Special Dock Area we want to avoid dropping on the center of it (i.e. we don't want this widget to be ever tabbified):
@@ -431,6 +433,9 @@ CMainWindow::CMainWindow(QWidget *parent) :
 
 	// uncomment the following line if you don't want tabs menu button on DockArea's title bar
 	//CDockManager::setConfigFlag(CDockManager::DockAreaHasTabsMenuButton, false);
+
+	// uncomment the following line if you don't want disabled buttons to appear on DockArea's title bar
+	//CDockManager::setConfigFlag(CDockManager::DockAreaHideDisabledButtons, true);
 
 	// Now create the dock manager and its content
 	d->DockManager = new CDockManager(this);

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -58,8 +58,8 @@ using tTitleBarButton = QToolButton;
 /**
  * Title bar button of a dock area that customizes tTitleBarButton appearance/behaviour
  * according to various config flags such as:
- * CDockManager::DockAreaHasCloseButton - keeps the button always invisible
- * CDockManager::DockAreaHideDisabledButtons - hides button when it is disabled
+ * CDockManager::DockAreaHas_xxx_Button - if set to 'false' keeps the button always invisible
+ * CDockManager::DockAreaHideDisabledButtons - if set to 'true' hides button when it is disabled
  */
 class CTitleBarButton : public tTitleBarButton
 {

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -59,6 +59,7 @@ using tTitleBarButton = QToolButton;
  * Title bar icon of a dock area that customizes tTitleBarButton appearance/behaviour
  * according to various config flags such as:
  * CDockManager::DockAreaHasCloseButton - keeps the button always invisible
+ * CDockManager::DockAreaHideDisabledButtons - hides button when it is disabled
  */
 class CTitleBarButton : public tTitleBarButton
 {

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -106,28 +106,6 @@ protected:
 
 
 
-class CInvisibleWhenDisabledButton : public tTitleBarButton
-{
-public:
-    virtual void setVisible(bool visible) override
-    {
-    	Q_UNUSED(visible);
-        tTitleBarButton::setVisible(visible && isEnabled());
-    }
-protected:
-    bool event(QEvent *ev) override
-    {
-        bool res = tTitleBarButton::event(ev);
-        if(ev->type() == QEvent::EnabledChange)
-        {
-            setVisible(isEnabled());
-        }
-        return res;
-    }
-};
-
-
-
 /**
  * Private data class of CDockAreaTitleBar class (pimpl)
  */

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -56,7 +56,7 @@ namespace ads
 using tTitleBarButton = QToolButton;
 
 /**
- * Title bar icon of a dock area that customizes tTitleBarButton appearance/behaviour
+ * Title bar button of a dock area that customizes tTitleBarButton appearance/behaviour
  * according to various config flags such as:
  * CDockManager::DockAreaHasCloseButton - keeps the button always invisible
  * CDockManager::DockAreaHideDisabledButtons - hides button when it is disabled

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -837,6 +837,12 @@ void CDockManager::setConfigFlag(eConfigFlag Flag, bool On)
 	internal::setFlag(StaticConfigFlags, Flag, On);
 }
 
+//===========================================================================
+bool CDockManager::testConfigFlag(eConfigFlag Flag)
+{
+    return configFlags().testFlag(Flag);
+}
+
 
 //===========================================================================
 CIconProvider& CDockManager::iconProvider()

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -159,6 +159,7 @@ public:
         AlwaysShowTabs = 0x2000,///< If this option is enabled, the tab of a dock widget is always displayed - even if it is the only visible dock widget in a floating widget.
         DockAreaHasUndockButton = 0x4000,     //!< If the flag is set each dock area has an undock button
         DockAreaHasTabsMenuButton = 0x8000,     //!< If the flag is set each dock area has a tabs menu button
+        DockAreaHideDisabledButtons = 0x10000,    //!< If the flag is set disabled dock area buttons will not appear on the tollbar at all (enabling them will bring them back)
 		DefaultConfig = ActiveTabHasCloseButton
 		              | DockAreaHasCloseButton
 		              | DockAreaHasUndockButton

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -214,6 +214,11 @@ public:
 	static void setConfigFlag(eConfigFlag Flag, bool On = true);
 
 	/**
+	 * Returns true if the given config flag is set
+	 */
+	static bool testConfigFlag(eConfigFlag Flag);
+
+	/**
 	 * Returns the global icon provider.
 	 * The icon provider enables the use of custom icons in case using
 	 * styleheets for icons is not an option.


### PR DESCRIPTION
When this flag is set disabled dock area buttons will not appear on the tollbar at all (enabling them will bring them back)

(This serves not just "CentalWidget" purpose but to me seems to be a generally possible user preference)