### PR TITLE
Support a custom widget in the tab bar

### DIFF
--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -56,6 +56,7 @@
 #include <QScreen>
 #include <QStyle>
 #include <QMessageBox>
+#include <QPushButton>
 
 #ifdef Q_OS_WIN
 #include <QAxWidget>
@@ -248,6 +249,11 @@ struct MainWindowPrivate
 	void createContent();
 
 	/**
+	 * Creates a plus button in the tab bar.
+	 */
+	QWidget* createPlusButton(ads::CDockAreaWidget* area);
+
+	/**
 	 * Saves the dock manager state and the main window geometry
 	 */
 	void saveState();
@@ -268,12 +274,32 @@ struct MainWindowPrivate
 	void restorePerspectives();
 };
 
+//============================================================================
+QWidget* MainWindowPrivate::createPlusButton(ads::CDockAreaWidget* area)
+{
+	auto button = new QPushButton("+", area);
+	button->setMaximumWidth(30);
+
+	QObject::connect(button, &QPushButton::clicked, DockManager, [this, area]() {
+		auto filesystem = createFileSystemTreeDockWidget(ui.menuView);
+		DockManager->addDockWidgetTabToArea(filesystem, area);
+	});
+
+	return button;
+}
 
 //============================================================================
 void MainWindowPrivate::createContent()
 {
 	// Test container docking
 	QMenu* ViewMenu = ui.menuView;
+
+	const auto creator =
+		[this](ads::CDockAreaWidget* area) -> QWidget* {
+			return MainWindowPrivate::createPlusButton(area);
+		};
+	DockManager->setCustomTabWidgetCreator(creator);
+
 	auto DockWidget = createCalendarDockWidget(ViewMenu);
 	DockWidget->setFeature(ads::CDockWidget::DockWidgetClosable, false);
 	DockWidget->setFeature(ads::CDockWidget::DockWidgetMovable, false);

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -223,6 +223,8 @@ void DockAreaTitleBarPrivate::createButtons()
 void DockAreaTitleBarPrivate::createTabBar()
 {
 	TabBar = new CDockAreaTabBar(DockArea);
+    // tab shouldn't occupy more horizontal space than needed
+	TabBar->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 	TopLayout->addWidget(TabBar);
 	_this->connect(TabBar, SIGNAL(tabClosed(int)), SLOT(markTabsMenuOutdated()));
 	_this->connect(TabBar, SIGNAL(tabOpened(int)), SLOT(markTabsMenuOutdated()));
@@ -253,6 +255,8 @@ CDockAreaTitleBar::CDockAreaTitleBar(CDockAreaWidget* parent) :
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
 	d->createTabBar();
+	// moved from DockAreaTabBar to ensure the custom widget is next to the tab bar
+	d->TopLayout->addStretch(1);
 	d->createButtons();
 
 }
@@ -388,6 +392,24 @@ void CDockAreaTitleBar::setVisible(bool Visible)
 {
 	Super::setVisible(Visible);
 	markTabsMenuOutdated();
+}
+
+//============================================================================
+void CDockAreaTitleBar::mousePressEvent(QMouseEvent * ev)
+{
+	d->TabBar->mousePressEvent(ev);
+}
+
+//============================================================================
+void CDockAreaTitleBar::mouseReleaseEvent(QMouseEvent * ev)
+{
+	d->TabBar->mouseReleaseEvent(ev);
+}
+
+//============================================================================
+void CDockAreaTitleBar::mouseMoveEvent(QMouseEvent * ev)
+{
+	d->TabBar->mouseMoveEvent(ev);
 }
 
 

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -255,6 +255,11 @@ CDockAreaTitleBar::CDockAreaTitleBar(CDockAreaWidget* parent) :
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
 	d->createTabBar();
+	const auto creator = d->DockArea->dockManager()->customTabWidgetCreator();
+	if (QWidget* widget = creator(d->DockArea))
+	{
+		d->TopLayout->addWidget(widget);
+	}
 	// moved from DockAreaTabBar to ensure the custom widget is next to the tab bar
 	d->TopLayout->addStretch(1);
 	d->createButtons();

--- a/src/DockAreaTitleBar.h
+++ b/src/DockAreaTitleBar.h
@@ -98,6 +98,22 @@ public:
 	 */
 	virtual void setVisible(bool Visible) override;
 
+	/**
+	 * Stores mouse position to detect dragging
+	 */
+	virtual void mousePressEvent(QMouseEvent* ev) override;
+
+	/**
+	 * Stores mouse position to detect dragging
+	 */
+	virtual void mouseReleaseEvent(QMouseEvent* ev) override;
+
+	/**
+	 * Starts floating the complete docking area including all dock widgets,
+	 * if it is not the last dock area in a floating widget
+	 */
+	virtual void mouseMoveEvent(QMouseEvent* ev) override;
+
 
 signals:
 	/**

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -77,6 +77,7 @@ struct DockManagerPrivate
 	CDockManager::eViewMenuInsertionOrder MenuInsertionOrder = CDockManager::MenuAlphabeticallySorted;
 	bool RestoringState = false;
 	QVector<CFloatingDockContainer*> UninitializedFloatingWidgets;
+	CDockManager::CustomTabWidgetCreator CustomTabWidgetCreator = [](CDockAreaWidget*) { return nullptr; };
 
 	/**
 	 * Private data constructor
@@ -849,6 +850,18 @@ CIconProvider& CDockManager::iconProvider()
 {
 	static CIconProvider Instance;
 	return Instance;
+}
+
+//===========================================================================
+void CDockManager::setCustomTabWidgetCreator(const CustomTabWidgetCreator Creator)
+{
+	d->CustomTabWidgetCreator = Creator;
+}
+
+//===========================================================================
+const CDockManager::CustomTabWidgetCreator& CDockManager::customTabWidgetCreator() const
+{
+	return d->CustomTabWidgetCreator;
 }
 
 

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -130,6 +130,7 @@ protected:
 
 public:
 	using Super = CDockContainerWidget;
+	using CustomTabWidgetCreator = std::function<QWidget*(CDockAreaWidget*)>;
 
 	enum eViewMenuInsertionOrder
 	{
@@ -400,6 +401,22 @@ public:
 	 * hold down before a dock widget start floating
 	 */
 	static int startDragDistance();
+
+	/**
+	 * Sets a creator function that is used to create a custom tab widget.
+	 * The custom tab widget will be placed at the right hand side of the tab bar.
+	 * The creator function will be called with a CDockAreaWidget as the only
+	 * parameter. It should return a new instance of the custom tab widget.
+	 *
+	 * This creator function can be used to create a plus button to add new
+	 * tabs, similar to Google Chrome. See the demo for an example.
+	 */
+	void setCustomTabWidgetCreator(const CustomTabWidgetCreator Creator);
+
+	/**
+	 * Returns the current creator function for the custom tab widget.
+	 */
+	const CDockManager::CustomTabWidgetCreator& customTabWidgetCreator() const;
 
 public slots:
 	/**


### PR DESCRIPTION
Hi, this PR adds support for a custom widget that resides on the right hand side of the tab bar. This way ADS can support a plus button like the ones in firefox or chrome. The plus button is only one example, the user can add any QWidget they want.

The following gif shows this feature in action:
![ads](https://user-images.githubusercontent.com/12886563/73871849-e2539980-484e-11ea-9846-a04920f4ac5a.gif)

