### PR TITLE
Added CDockManager::floatingWidgetCreated event

### DIFF
--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -440,6 +440,7 @@ CDockManager::~CDockManager()
 void CDockManager::registerFloatingWidget(CFloatingDockContainer* FloatingWidget)
 {
 	d->FloatingWidgets.append(FloatingWidget);
+	emit floatingWidgetCreated(FloatingWidget);
     ADS_PRINT("d->FloatingWidgets.count() " << d->FloatingWidgets.count());
 }
 

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -450,9 +450,16 @@ signals:
 
     /**
      * This signal is emitted if the dock manager finished opening a
-     * perspective
+     * perspective.
      */
     void perspectiveOpened(const QString& PerspectiveName);
+
+	/**
+	 * This signal is emitted, if a new floating widget has been created.
+	 * An application can use this signal to e.g. subscribe to events of
+	 * the newly created window.
+	 */
+	void floatingWidgetCreated(CFloatingDockContainer* FloatingWidget);
 
     /**
      * This signal is emitted, if a new DockArea has been created.


### PR DESCRIPTION
This allows to subscribe to events of the newly created window.
A common use case is to show a message box if a dock container with many modified documents in it is closed. This allows for the user to decide whether he wants to save / discard all the changes or cancel the closing of the window.