### PR TITLE
FIX: DockContainerWidget::dropWidget API change not reflected in Python bindings

### DIFF
--- a/sip/DockContainerWidget.sip
+++ b/sip/DockContainerWidget.sip
@@ -23,7 +23,7 @@ protected:
 	QSplitter* rootSplitter() const;
 	void createRootSplitter();
 	void dropFloatingWidget(ads::CFloatingDockContainer* FloatingWidget, const QPoint& TargetPos);
-    void dropWidget(QWidget* widget, const QPoint& TargetPos);
+    void dropWidget(QWidget* Widget, DockWidgetArea DropArea, CDockAreaWidget* TargetAreaWidget);
 	void addDockArea(ads::CDockAreaWidget* DockAreaWidget /Transfer/, ads::DockWidgetArea area = ads::CenterDockWidgetArea);
 	void removeDockArea(ads::CDockAreaWidget* area /TransferBack/);
 	void saveState(QXmlStreamWriter& Stream) const;

--- a/sip/DockOverlay.sip
+++ b/sip/DockOverlay.sip
@@ -24,6 +24,7 @@ public:
 	void setAllowedAreas(ads::DockWidgetAreas areas);
 	ads::DockWidgetAreas allowedAreas() const;
 	ads::DockWidgetArea dropAreaUnderCursor() const;
+    ads::DockWidgetArea visibleDropAreaUnderCursor() const;
 	ads::DockWidgetArea showOverlay(QWidget* target);
 	void hideOverlay();
 	void enableDropPreview(bool Enable);

--- a/sip/DockSplitter.sip
+++ b/sip/DockSplitter.sip
@@ -16,6 +16,9 @@ public:
 	CDockSplitter(Qt::Orientation orientation, QWidget *parent /TransferThis/ = 0);
 	virtual ~CDockSplitter();
 	bool hasVisibleContent() const;
+	QWidget* firstWidget() const;
+	QWidget* lastWidget() const;
+
 };
 
 };


### PR DESCRIPTION
Fixes building for 3.2.4:
* Adds CDockAreaWidget argument

Adds missing bindings for:
* CDockOverlay::visibleDropAreaUnderCursor
* CDockSplitter::firstWidget
* CDockSplitter::lastWidget

@githubuser0xFFFF, would you allow an addition to the Travis CI configuration to build the Python bindings on each commit? It could be made `xfail` such that it doesn't get in the way of your development, but it could also give us (@n-elie and @hhslepicka) a heads-up when we need to fix it.