### PR TITLE
Fix memory leak

### DIFF
--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -68,6 +68,8 @@ class CDockingStateReader;
 class IFloatingWidget
 {
 public:
+    virtual ~IFloatingWidget() = default;
+
 	/**
 	 * Starts floating.
 	 * This function should get called typically from a mouse press event


### PR DESCRIPTION
A memory leak is caused by missing the virtual destructor in IFloatingWidget.