### PR TITLE
Moved CTitleBarButton declaration into DockAreaTitleBar.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(ads_INSTALL_INCLUDE
     src/ads_globals.h
     src/DockAreaTabBar.h
     src/DockAreaTitleBar.h
+	src/DockAreaTitleBar_p.h
     src/DockAreaWidget.h
     src/DockContainerWidget.h
     src/DockManager.h

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -55,8 +55,6 @@
 
 namespace ads
 {
-using tTitleBarButton = QToolButton;
-
 
 /**
  * Private data class of CDockAreaTitleBar class (pimpl)
@@ -129,86 +127,6 @@ struct DockAreaTitleBarPrivate
 	 */
 	IFloatingWidget* makeAreaFloating(const QPoint& Offset, eDragState DragState);
 };// struct DockAreaTitleBarPrivate
-
-
-/**
- * Title bar button of a dock area that customizes tTitleBarButton appearance/behaviour
- * according to various config flags such as:
- * CDockManager::DockAreaHas_xxx_Button - if set to 'false' keeps the button always invisible
- * CDockManager::DockAreaHideDisabledButtons - if set to 'true' hides button when it is disabled
- */
-class CTitleBarButton : public tTitleBarButton
-{
-	Q_OBJECT
-	bool Visible = true;
-	bool HideWhenDisabled = false;
-public:
-	using Super = tTitleBarButton;
-	CTitleBarButton(bool visible = true, QWidget* parent = nullptr)
-		: tTitleBarButton(parent),
-		  Visible(visible),
-		  HideWhenDisabled(DockAreaTitleBarPrivate::testConfigFlag(CDockManager::DockAreaHideDisabledButtons))
-	{}
-	
-
-	/**
-	 * Adjust this visibility change request with our internal settings:
-	 */
-	virtual void setVisible(bool visible) override
-	{
-		// 'visible' can stay 'true' if and only if this button is configured to generaly visible:
-		visible = visible && this->Visible;
-
-		// 'visible' can stay 'true' unless: this button is configured to be invisible when it is disabled and it is currently disabled:
-		if(visible && HideWhenDisabled)
-		{
-			visible = isEnabled();
-		}
-
-		Super::setVisible(visible);
-	}
-	
-protected:
-	/**
-	 * Handle EnabledChanged signal to set button invisible if the configured
-	 */
-	bool event(QEvent *ev) override
-	{
-		if(QEvent::EnabledChange == ev->type() && HideWhenDisabled)
-		{
-			// force setVisible() call 
-			// Calling setVisible() directly here doesn't work well when button is expected to be shown first time
-			QMetaObject::invokeMethod(this, "setVisible", Qt::QueuedConnection, Q_ARG(bool, isEnabled()));
-		}
-
-		return Super::event(ev);
-	}
-};
-
-
-/**
- * This spacer widget is here because of the following problem.
- * The dock area title bar handles mouse dragging and moving the floating widget.
- * The  problem is, that if the title bar becomes invisible, i.e. if the dock
- * area contains only one single dock widget and the dock area is moved
- * into a floating widget, then mouse events are not handled anymore and dragging
- * of the floating widget stops.
- */
-class CSpacerWidget : public QWidget
-{
-	Q_OBJECT
-public:
-	using Super = QWidget;
-	CSpacerWidget(QWidget* Parent = 0)
-	    : Super(Parent)
-	{
-	    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-	    setStyleSheet("border: none; background: none;");
-	}
-	virtual QSize sizeHint() const override {return QSize(0, 0);}
-	virtual QSize minimumSizeHint() const override {return QSize(0, 0);}
-};
-
 
 //============================================================================
 DockAreaTitleBarPrivate::DockAreaTitleBarPrivate(CDockAreaTitleBar* _public) :
@@ -674,10 +592,50 @@ int CDockAreaTitleBar::indexOf(QWidget *widget) const
 	return d->Layout->indexOf(widget);
 }
 
+//============================================================================
+CTitleBarButton::CTitleBarButton(bool visible /*= true*/, QWidget* parent /*= nullptr*/) : tTitleBarButton(parent),
+Visible(visible),
+HideWhenDisabled(DockAreaTitleBarPrivate::testConfigFlag(CDockManager::DockAreaHideDisabledButtons))
+{
+
+}
+
+//============================================================================
+void CTitleBarButton::setVisible(bool visible)
+{
+	// 'visible' can stay 'true' if and only if this button is configured to generaly visible:
+	visible = visible && this->Visible;
+
+	// 'visible' can stay 'true' unless: this button is configured to be invisible when it is disabled and it is currently disabled:
+	if (visible && HideWhenDisabled)
+	{
+		visible = isEnabled();
+	}
+
+	Super::setVisible(visible);
+}
+
+//============================================================================
+bool CTitleBarButton::event(QEvent *ev)
+{
+	if (QEvent::EnabledChange == ev->type() && HideWhenDisabled)
+	{
+		// force setVisible() call 
+		// Calling setVisible() directly here doesn't work well when button is expected to be shown first time
+		QMetaObject::invokeMethod(this, "setVisible", Qt::QueuedConnection, Q_ARG(bool, isEnabled()));
+	}
+
+	return Super::event(ev);
+}
+
+//============================================================================
+CSpacerWidget::CSpacerWidget(QWidget* Parent /*= 0*/) : Super(Parent)
+{
+	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+	setStyleSheet("border: none; background: none;");
+}
 
 } // namespace ads
-
-#include "DockAreaTitleBar.moc"
 
 //---------------------------------------------------------------------------
 // EOF DockAreaTitleBar.cpp

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -39,6 +39,7 @@
 #include <QDebug>
 #include <QPointer>
 
+#include "DockAreaTitleBar_p.h"
 #include "ads_globals.h"
 #include "FloatingDockContainer.h"
 #include "FloatingDragPreview.h"

--- a/src/DockAreaTitleBar.h
+++ b/src/DockAreaTitleBar.h
@@ -31,6 +31,7 @@
 //                                   INCLUDES
 //============================================================================
 #include <QFrame>
+#include <QToolButton>
 
 #include "ads_globals.h"
 
@@ -155,6 +156,57 @@ signals:
 	 */
 	void tabBarClicked(int index);
 }; // class name
+
+using tTitleBarButton = QToolButton;
+
+   /**
+   * Title bar button of a dock area that customizes tTitleBarButton appearance/behaviour
+   * according to various config flags such as:
+   * CDockManager::DockAreaHas_xxx_Button - if set to 'false' keeps the button always invisible
+   * CDockManager::DockAreaHideDisabledButtons - if set to 'true' hides button when it is disabled
+   */
+class CTitleBarButton : public tTitleBarButton
+{
+	Q_OBJECT
+		
+	bool Visible = true;
+	bool HideWhenDisabled = false;
+
+public:
+	using Super = tTitleBarButton;
+	CTitleBarButton(bool visible = true, QWidget* parent = nullptr);
+
+	/**
+	* Adjust this visibility change request with our internal settings:
+	*/
+	virtual void setVisible(bool visible) override;
+
+protected:
+	/**
+	* Handle EnabledChanged signal to set button invisible if the configured
+	*/
+	bool event(QEvent *ev) override;
+};
+
+
+/**
+* This spacer widget is here because of the following problem.
+* The dock area title bar handles mouse dragging and moving the floating widget.
+* The  problem is, that if the title bar becomes invisible, i.e. if the dock
+* area contains only one single dock widget and the dock area is moved
+* into a floating widget, then mouse events are not handled anymore and dragging
+* of the floating widget stops.
+*/
+class CSpacerWidget : public QWidget
+{
+	Q_OBJECT
+public:
+	using Super = QWidget;
+	CSpacerWidget(QWidget* Parent = 0);
+	virtual QSize sizeHint() const override {return QSize(0, 0);}
+	virtual QSize minimumSizeHint() const override {return QSize(0, 0);}
+};
+
 }
  // namespace ads
 //-----------------------------------------------------------------------------

--- a/src/DockAreaTitleBar.h
+++ b/src/DockAreaTitleBar.h
@@ -31,7 +31,6 @@
 //                                   INCLUDES
 //============================================================================
 #include <QFrame>
-#include <QToolButton>
 
 #include "ads_globals.h"
 
@@ -156,56 +155,6 @@ signals:
 	 */
 	void tabBarClicked(int index);
 }; // class name
-
-using tTitleBarButton = QToolButton;
-
-   /**
-   * Title bar button of a dock area that customizes tTitleBarButton appearance/behaviour
-   * according to various config flags such as:
-   * CDockManager::DockAreaHas_xxx_Button - if set to 'false' keeps the button always invisible
-   * CDockManager::DockAreaHideDisabledButtons - if set to 'true' hides button when it is disabled
-   */
-class CTitleBarButton : public tTitleBarButton
-{
-	Q_OBJECT
-		
-	bool Visible = true;
-	bool HideWhenDisabled = false;
-
-public:
-	using Super = tTitleBarButton;
-	CTitleBarButton(bool visible = true, QWidget* parent = nullptr);
-
-	/**
-	* Adjust this visibility change request with our internal settings:
-	*/
-	virtual void setVisible(bool visible) override;
-
-protected:
-	/**
-	* Handle EnabledChanged signal to set button invisible if the configured
-	*/
-	bool event(QEvent *ev) override;
-};
-
-
-/**
-* This spacer widget is here because of the following problem.
-* The dock area title bar handles mouse dragging and moving the floating widget.
-* The  problem is, that if the title bar becomes invisible, i.e. if the dock
-* area contains only one single dock widget and the dock area is moved
-* into a floating widget, then mouse events are not handled anymore and dragging
-* of the floating widget stops.
-*/
-class CSpacerWidget : public QWidget
-{
-	Q_OBJECT
-public:
-	using Super = QWidget;
-	CSpacerWidget(QWidget* Parent = 0);
-	virtual QSize sizeHint() const override {return QSize(0, 0);}
-	virtual QSize minimumSizeHint() const override {return QSize(0, 0);}
-};
 
 }
  // namespace ads

--- a/src/DockAreaTitleBar_p.h
+++ b/src/DockAreaTitleBar_p.h
@@ -1,0 +1,93 @@
+#ifndef DockAreaTitleBarPH
+#define DockAreaTitleBarPH
+/*******************************************************************************
+** Qt Advanced Docking System
+** Copyright (C) 2017 Uwe Kindler
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public
+** License along with this library; If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+
+//============================================================================
+/// \file   DockAreaTitleBar_p.h
+/// \author Uwe Kindler
+/// \date   12.10.2018
+/// \brief  Declaration of classes CTitleBarButton and CSpacerWidget
+//============================================================================
+
+
+//============================================================================
+//                                   INCLUDES
+//============================================================================
+#include <QFrame>
+#include <QToolButton>
+
+#include "ads_globals.h"
+
+namespace ads
+{
+using tTitleBarButton = QToolButton;
+
+   /**
+   * Title bar button of a dock area that customizes tTitleBarButton appearance/behaviour
+   * according to various config flags such as:
+   * CDockManager::DockAreaHas_xxx_Button - if set to 'false' keeps the button always invisible
+   * CDockManager::DockAreaHideDisabledButtons - if set to 'true' hides button when it is disabled
+   */
+class CTitleBarButton : public tTitleBarButton
+{
+	Q_OBJECT
+		
+	bool Visible = true;
+	bool HideWhenDisabled = false;
+
+public:
+	using Super = tTitleBarButton;
+	CTitleBarButton(bool visible = true, QWidget* parent = nullptr);
+
+	/**
+	* Adjust this visibility change request with our internal settings:
+	*/
+	virtual void setVisible(bool visible) override;
+
+protected:
+	/**
+	* Handle EnabledChanged signal to set button invisible if the configured
+	*/
+	bool event(QEvent *ev) override;
+};
+
+
+/**
+* This spacer widget is here because of the following problem.
+* The dock area title bar handles mouse dragging and moving the floating widget.
+* The  problem is, that if the title bar becomes invisible, i.e. if the dock
+* area contains only one single dock widget and the dock area is moved
+* into a floating widget, then mouse events are not handled anymore and dragging
+* of the floating widget stops.
+*/
+class CSpacerWidget : public QWidget
+{
+	Q_OBJECT
+public:
+	using Super = QWidget;
+	CSpacerWidget(QWidget* Parent = 0);
+	virtual QSize sizeHint() const override {return QSize(0, 0);}
+	virtual QSize minimumSizeHint() const override {return QSize(0, 0);}
+};
+
+}
+ // namespace ads
+//-----------------------------------------------------------------------------
+#endif // DockAreaTitleBarPH

--- a/src/src.pro
+++ b/src/src.pro
@@ -42,6 +42,7 @@ HEADERS += \
     DockOverlay.h \
     DockSplitter.h \
     DockAreaTitleBar.h \
+	DockAreaTitleBar_p.h \
     ElidingLabel.h \
     IconProvider.h \
     DockComponentsFactory.h 


### PR DESCRIPTION
This gets rid of the need to MOC DockAreaTitleBar.cpp and it means that DockAreaTitleBar.cpp does not need to #include "DockAreaTitleBar.moc" anymore, which is a file that is generated by the build system and therefore may be named differently when using a custom build system.

Fix for #166 