### PR TITLE
Support for Qt built with the -qtnamespace configure option

### DIFF
--- a/examples/sidebar/MainWindow.h
+++ b/examples/sidebar/MainWindow.h
@@ -4,10 +4,11 @@
 #include <QMainWindow>
 #include "DockManager.h"
 
+QT_BEGIN_NAMESPACE
 namespace Ui {
 class MainWindow;
 }
-
+QT_END_NAMESPACE
 
 /**
  * This example shows, how to place a dock widget container and a static

--- a/examples/simple/MainWindow.h
+++ b/examples/simple/MainWindow.h
@@ -4,9 +4,11 @@
 #include <QMainWindow>
 #include "DockManager.h"
 
+QT_BEGIN_NAMESPACE
 namespace Ui {
 class MainWindow;
 }
+QT_END_NAMESPACE
 
 class MainWindow : public QMainWindow
 {

--- a/src/DockAreaTitleBar.h
+++ b/src/DockAreaTitleBar.h
@@ -34,7 +34,7 @@
 
 #include "ads_globals.h"
 
-class QAbstractButton;
+QT_FORWARD_DECLARE_CLASS(QAbstractButton);
 
 namespace ads
 {

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -35,8 +35,8 @@
 #include "ads_globals.h"
 #include "DockWidget.h"
 
-class QXmlStreamWriter;
-class QAbstractButton;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter);
+QT_FORWARD_DECLARE_CLASS(QAbstractButton);
 
 namespace ads
 {

--- a/src/DockContainerWidget.h
+++ b/src/DockContainerWidget.h
@@ -35,7 +35,7 @@
 #include "ads_globals.h"
 #include "DockWidget.h"
 
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter);
 
 
 namespace ads

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -36,8 +36,8 @@
 #include "FloatingDockContainer.h"
 
 
-class QSettings;
-class QMenu;
+QT_FORWARD_DECLARE_CLASS(QSettings);
+QT_FORWARD_DECLARE_CLASS(QMenu);
 
 namespace ads
 {

--- a/src/DockOverlay.h
+++ b/src/DockOverlay.h
@@ -26,7 +26,7 @@
 #include <QHash>
 #include <QRect>
 #include <QFrame>
-class QGridLayout;
+QT_FORWARD_DECLARE_CLASS(QGridLayout);
 
 #include "ads_globals.h"
 

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -34,8 +34,8 @@
 
 #include "ads_globals.h"
 
-class QToolBar;
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QToolBar);
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter);
 
 namespace ads
 {

--- a/src/ads_globals.h
+++ b/src/ads_globals.h
@@ -37,7 +37,7 @@
 #include <QDebug>
 #include <QStyle>
 
-class QAbstractButton;
+QT_FORWARD_DECLARE_CLASS(QAbstractButton);
 
 #ifndef ADS_STATIC
 #ifdef ADS_SHARED_EXPORT
@@ -60,7 +60,7 @@ class QAbstractButton;
 // dumps to qDebug and std::cout after layout changes
 #define ADS_DEBUG_LEVEL 0
 
-class QSplitter;
+QT_FORWARD_DECLARE_CLASS(QSplitter);
 
 namespace ads
 {


### PR DESCRIPTION
Qt classes should be forward declared with QT_FORWARD_DECLARE_CLASS, because some builds of Qt declare everything inside a namespace.