### PR TITLE
Fixed issue #179 - appearance of drop indicators

### DIFF
--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -40,16 +40,15 @@
 #include <QElapsedTimer>
 #include <QTime>
 
-// widows
-#include <QtCore>
-#include <windows.h>
-
 #include "DockContainerWidget.h"
 #include "DockAreaWidget.h"
 #include "DockManager.h"
 #include "DockWidget.h"
 #include "DockOverlay.h"
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
 #ifdef Q_OS_LINUX
 #include "linux/FloatingWidgetTitleBar.h"
 #include <xcb/xcb.h>

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -590,6 +590,7 @@ bool CFloatingDockContainer::eventFilter(QObject *watched, QEvent *e)
 #ifdef Q_OS_WIN
 bool CFloatingDockContainer::nativeEvent(const QByteArray &eventType, void *message, long *result)
 {
+	QWidget::nativeEvent(eventType, message, result);
 	MSG *msg = static_cast<MSG*>(message);
 	if (msg->message == WM_MOVING)
 	{

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -184,6 +184,9 @@ protected: // reimplements QWidget
 	virtual void showEvent(QShowEvent *event) override;
 	virtual bool eventFilter(QObject *watched, QEvent *event) override;
 
+#ifdef Q_OS_WIN
+	virtual bool nativeEvent(const QByteArray &eventType, void *message, long *result) override;
+#endif
 public:
 	using Super = QWidget;
 


### PR DESCRIPTION
Fix appearance of drop indicators then Windows option "Show window contents while dragging"  is off
https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/179