### PR TITLE
Fixed missing lib in qmake

### DIFF
--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -48,9 +48,6 @@
 
 #ifdef Q_OS_WIN
 #include <windows.h>
-#ifdef _MSC_VER
-#pragma comment(lib, "User32.lib")
-#endif
 #endif
 #ifdef Q_OS_LINUX
 #include "linux/FloatingWidgetTitleBar.h"

--- a/src/src.pro
+++ b/src/src.pro
@@ -66,7 +66,9 @@ SOURCES += \
     IconProvider.cpp \
     DockComponentsFactory.cpp
 
-
+win32 {
+    LIBS += -lUser32
+}
 unix {
 HEADERS += linux/FloatingWidgetTitleBar.h
 SOURCES += linux/FloatingWidgetTitleBar.cpp


### PR DESCRIPTION
This fixes the MSVC build for sure but might break the MinGW one, if that's the case I'll solve ina different way