### PR TITLE
Clear some shadow warnings

### DIFF
--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -403,10 +403,10 @@ void MainWindowPrivate::createContent()
 	TitleBar->insertWidget(Index + 1, CustomButton);
 	QObject::connect(CustomButton, &QToolButton::clicked, [=]()
 	{
-		auto DockWidget = createEditorWidget(ui.menuView);
-		DockWidget->setFeature(ads::CDockWidget::DockWidgetDeleteOnClose, true);
-		DockManager->addDockWidgetTabToArea(DockWidget, DockArea);
-		_this->connect(DockWidget, SIGNAL(closeRequested()), SLOT(onEditorCloseRequested()));
+		auto LDockWidget = createEditorWidget(ui.menuView);
+		LDockWidget->setFeature(ads::CDockWidget::DockWidgetDeleteOnClose, true);
+		DockManager->addDockWidgetTabToArea(LDockWidget, DockArea);
+		_this->connect(LDockWidget, SIGNAL(closeRequested()), SLOT(onEditorCloseRequested()));
 	});
 
 	// Test dock area docking
@@ -430,10 +430,10 @@ void MainWindowPrivate::createContent()
     }
 #endif
 
-	for (auto DockWidget : DockManager->dockWidgetsMap())
+	for (auto LDockWidget : DockManager->dockWidgetsMap())
 	{
-		_this->connect(DockWidget, SIGNAL(viewToggled(bool)), SLOT(onViewToggled(bool)));
-		_this->connect(DockWidget, SIGNAL(visibilityChanged(bool)), SLOT(onViewVisibilityChanged(bool)));
+		_this->connect(LDockWidget, SIGNAL(viewToggled(bool)), SLOT(onViewToggled(bool)));
+		_this->connect(LDockWidget, SIGNAL(visibilityChanged(bool)), SLOT(onViewVisibilityChanged(bool)));
 	}
 }
 

--- a/examples/sidebar/main.cpp
+++ b/examples/sidebar/main.cpp
@@ -1,5 +1,5 @@
 #include <QApplication>
-#include "../../examples/simple/MainWindow.h"
+#include "./MainWindow.h"
 
 int main(int argc, char *argv[])
 {

--- a/examples/simple/MainWindow.cpp
+++ b/examples/simple/MainWindow.cpp
@@ -1,4 +1,4 @@
-#include "../../examples/simple/MainWindow.h"
+#include "./MainWindow.h"
 
 #include "ui_MainWindow.h"
 

--- a/examples/simple/main.cpp
+++ b/examples/simple/main.cpp
@@ -1,5 +1,5 @@
 #include <QApplication>
-#include "../../examples/simple/MainWindow.h"
+#include "./MainWindow.h"
 
 int main(int argc, char *argv[])
 {

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -149,12 +149,12 @@ void DockAreaTitleBarPrivate::createButtons()
 	TabsMenuButton->setAutoRaise(true);
 	TabsMenuButton->setPopupMode(QToolButton::InstantPopup);
 	internal::setButtonIcon(TabsMenuButton, QStyle::SP_TitleBarUnshadeButton, ads::DockAreaMenuIcon);
-	QMenu* TabsMenu = new QMenu(TabsMenuButton);
+	QMenu* LTabsMenu = new QMenu(TabsMenuButton);
 #ifndef QT_NO_TOOLTIP
-	TabsMenu->setToolTipsVisible(true);
+	LTabsMenu->setToolTipsVisible(true);
 #endif
-	_this->connect(TabsMenu, SIGNAL(aboutToShow()), SLOT(onTabsMenuAboutToShow()));
-	TabsMenuButton->setMenu(TabsMenu);
+	_this->connect(LTabsMenu, SIGNAL(aboutToShow()), SLOT(onTabsMenuAboutToShow()));
+	TabsMenuButton->setMenu(LTabsMenu);
 	internal::setToolTip(TabsMenuButton, QObject::tr("List All Tabs"));
 	TabsMenuButton->setSizePolicy(ButtonSizePolicy);
 	Layout->addWidget(TabsMenuButton, 0);
@@ -209,17 +209,17 @@ void DockAreaTitleBarPrivate::createTabBar()
 
 
 //============================================================================
-IFloatingWidget* DockAreaTitleBarPrivate::makeAreaFloating(const QPoint& Offset, eDragState DragState)
+IFloatingWidget* DockAreaTitleBarPrivate::makeAreaFloating(const QPoint& Offset, eDragState LDragState)
 {
 	QSize Size = DockArea->size();
-	this->DragState = DragState;
+	this->DragState = LDragState;
 	bool OpaqueUndocking = CDockManager::testConfigFlag(CDockManager::OpaqueUndocking) ||
-		(DraggingFloatingWidget != DragState);
+		(DraggingFloatingWidget != LDragState);
 	CFloatingDockContainer* FloatingDockContainer = nullptr;
-	IFloatingWidget* FloatingWidget;
+	IFloatingWidget* LFloatingWidget;
 	if (OpaqueUndocking)
 	{
-		FloatingWidget = FloatingDockContainer = new CFloatingDockContainer(DockArea);
+		LFloatingWidget = FloatingDockContainer = new CFloatingDockContainer(DockArea);
 	}
 	else
 	{
@@ -228,10 +228,10 @@ IFloatingWidget* DockAreaTitleBarPrivate::makeAreaFloating(const QPoint& Offset,
 		{
 			this->DragState = DraggingInactive;
 		});
-		FloatingWidget = w;
+		LFloatingWidget = w;
 	}
 
-    FloatingWidget->startFloating(Offset, Size, DragState, nullptr);
+    LFloatingWidget->startFloating(Offset, Size, LDragState, nullptr);
     if (FloatingDockContainer)
     {
 		auto TopLevelDockWidget = FloatingDockContainer->topLevelDockWidget();
@@ -241,7 +241,7 @@ IFloatingWidget* DockAreaTitleBarPrivate::makeAreaFloating(const QPoint& Offset,
 		}
     }
 
-	return FloatingWidget;
+	return LFloatingWidget;
 }
 
 

--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -385,13 +385,13 @@ eDropMode DockContainerWidgetPrivate::getDropMode(const QPoint& TargetPos)
 //============================================================================
 void DockContainerWidgetPrivate::onVisibleDockAreaCountChanged()
 {
-	auto TopLevelDockArea = _this->topLevelDockArea();
+	auto LTopLevelDockArea = _this->topLevelDockArea();
 
-	if (TopLevelDockArea)
+	if (LTopLevelDockArea)
 	{
-		this->TopLevelDockArea = TopLevelDockArea;
-		TopLevelDockArea->titleBarButton(TitleBarButtonUndock)->setVisible(false || !_this->isFloating());
-		TopLevelDockArea->titleBarButton(TitleBarButtonClose)->setVisible(false || !_this->isFloating());
+		this->TopLevelDockArea = LTopLevelDockArea;
+		LTopLevelDockArea->titleBarButton(TitleBarButtonUndock)->setVisible(false || !_this->isFloating());
+		LTopLevelDockArea->titleBarButton(TitleBarButtonClose)->setVisible(false || !_this->isFloating());
 	}
 	else if (this->TopLevelDockArea)
 	{
@@ -464,15 +464,15 @@ void DockContainerWidgetPrivate::dropIntoCenterOfSection(
 {
 	CDockContainerWidget* FloatingContainer = FloatingWidget->dockContainer();
 	auto NewDockWidgets = FloatingContainer->dockWidgets();
-	auto TopLevelDockArea = FloatingContainer->topLevelDockArea();
+	auto LTopLevelDockArea = FloatingContainer->topLevelDockArea();
 	int NewCurrentIndex = -1;
 
 	// If the floating widget contains only one single dock are, then the
 	// current dock widget of the dock area will also be the future current
 	// dock widget in the drop area.
-	if (TopLevelDockArea)
+	if (LTopLevelDockArea)
 	{
-		NewCurrentIndex = TopLevelDockArea->currentIndex();
+		NewCurrentIndex = LTopLevelDockArea->currentIndex();
 	}
 
 	for (int i = 0; i < NewDockWidgets.count(); ++i)
@@ -669,7 +669,7 @@ void DockContainerWidgetPrivate::moveToNewSection(QWidget* Widget, CDockAreaWidg
 	}
 	else
 	{
-		auto Sizes = TargetAreaSplitter->sizes();
+		//auto LSizes = TargetAreaSplitter->sizes();
 		int TargetAreaSize = (InsertParam.orientation() == Qt::Horizontal) ? TargetArea->width() : TargetArea->height();
 		QSplitter* NewSplitter = newSplitter(InsertParam.orientation());
 		NewSplitter->addWidget(TargetArea);

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -561,8 +561,8 @@ QByteArray CDockManager::saveState(int version) const
 {
     QByteArray xmldata;
     QXmlStreamWriter s(&xmldata);
-    auto ConfigFlags = CDockManager::configFlags();
-	s.setAutoFormatting(ConfigFlags.testFlag(XmlAutoFormattingEnabled));
+    auto LConfigFlags = CDockManager::configFlags();
+	s.setAutoFormatting(LConfigFlags.testFlag(XmlAutoFormattingEnabled));
     s.writeStartDocument();
 		s.writeStartElement("QtAdvancedDockingSystem");
 		s.writeAttribute("Version", QString::number(CurrentVersion));
@@ -576,7 +576,7 @@ QByteArray CDockManager::saveState(int version) const
 		s.writeEndElement();
     s.writeEndDocument();
 
-    return ConfigFlags.testFlag(XmlCompressionEnabled)
+    return LConfigFlags.testFlag(XmlCompressionEnabled)
     	? qCompress(xmldata, 9) : xmldata;
 }
 

--- a/src/DockOverlay.cpp
+++ b/src/DockOverlay.cpp
@@ -150,7 +150,7 @@ struct DockOverlayCrossPrivate
 
 	//============================================================================
 	QWidget* createDropIndicatorWidget(DockWidgetArea DockWidgetArea,
-		CDockOverlay::eMode Mode)
+		CDockOverlay::eMode LMode)
 	{
 		QLabel* l = new QLabel();
 		l->setObjectName("DockWidgetAreaLabel");
@@ -158,7 +158,7 @@ struct DockOverlayCrossPrivate
         const qreal metric = dropIndicatiorWidth(l);
 		const QSizeF size(metric, metric);
 
-		l->setPixmap(createHighDpiDropIndicatorPixmap(size, DockWidgetArea, Mode));
+		l->setPixmap(createHighDpiDropIndicatorPixmap(size, DockWidgetArea, LMode));
 		l->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
 		l->setAttribute(Qt::WA_TranslucentBackground);
 		l->setProperty("dockWidgetArea", DockWidgetArea);
@@ -178,7 +178,7 @@ struct DockOverlayCrossPrivate
 
 	//============================================================================
 	QPixmap createHighDpiDropIndicatorPixmap(const QSizeF& size, DockWidgetArea DockWidgetArea,
-		CDockOverlay::eMode Mode)
+		CDockOverlay::eMode LMode)
 	{
 		QColor borderColor = iconColor(CDockOverlayCross::FrameColor);
 		QColor backgroundColor = iconColor(CDockOverlayCross::WindowBackgroundColor);
@@ -239,7 +239,7 @@ struct DockOverlayCrossPrivate
 		}
 
 		QSizeF baseSize = baseRect.size();
-		if (CDockOverlay::ModeContainerOverlay == Mode && DockWidgetArea != CenterDockWidgetArea)
+		if (CDockOverlay::ModeContainerOverlay == LMode && DockWidgetArea != CenterDockWidgetArea)
 		{
 			baseRect = areaRect;
 		}
@@ -283,7 +283,7 @@ struct DockOverlayCrossPrivate
 		p.restore();
 
 		// Draw arrow for outer container drop indicators
-		if (CDockOverlay::ModeContainerOverlay == Mode && DockWidgetArea != CenterDockWidgetArea)
+		if (CDockOverlay::ModeContainerOverlay == LMode && DockWidgetArea != CenterDockWidgetArea)
 		{
 			QRectF ArrowRect;
 			ArrowRect.setSize(baseSize);

--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -242,7 +242,7 @@ bool DockWidgetTabPrivate::startFloating(eDragState DraggingState)
 
     ADS_PRINT("startFloating");
 	DragState = DraggingState;
-	IFloatingWidget* FloatingWidget = nullptr;
+	IFloatingWidget* LFloatingWidget = nullptr;
 	bool OpaqueUndocking = CDockManager::testConfigFlag(CDockManager::OpaqueUndocking) ||
 		(DraggingFloatingWidget != DraggingState);
 
@@ -252,21 +252,21 @@ bool DockWidgetTabPrivate::startFloating(eDragState DraggingState)
 	QSize Size;
 	if (DockArea->dockWidgetsCount() > 1)
 	{
-		FloatingWidget = createFloatingWidget(DockWidget, OpaqueUndocking);
+		LFloatingWidget = createFloatingWidget(DockWidget, OpaqueUndocking);
 		Size = DockWidget->size();
 	}
 	else
 	{
-		FloatingWidget = createFloatingWidget(DockArea, OpaqueUndocking);
+		LFloatingWidget = createFloatingWidget(DockArea, OpaqueUndocking);
 		Size = DockArea->size();
 	}
 
     if (DraggingFloatingWidget == DraggingState)
     {
-        FloatingWidget->startFloating(DragStartMousePosition, Size, DraggingFloatingWidget, _this);
+        LFloatingWidget->startFloating(DragStartMousePosition, Size, DraggingFloatingWidget, _this);
     	auto Overlay = DockWidget->dockManager()->containerOverlay();
     	Overlay->setAllowedAreas(OuterDockAreas);
-    	this->FloatingWidget = FloatingWidget;
+    	this->FloatingWidget = LFloatingWidget;
     }
     else
     {


### PR DESCRIPTION
Ran across a few -Wshadow warnings when building this code.  This change just attempts to clear them by renaming, and commenting out one unused var in DockContainerWidget.cpp.