### PR TITLE
Fix Undefined Behavior in LastAddedAreaCache

### DIFF
--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -1319,9 +1319,9 @@ void CDockContainerWidget::removeDockArea(CDockAreaWidget* area)
 	internal::hideEmptyParentSplitters(Splitter);
 
 	// Remove this area from cached areas
-	const auto& cache = d->LastAddedAreaCache;
-	if (auto p = std::find(cache, cache+sizeof(cache)/sizeof(cache[0]), area)) {
-		d->LastAddedAreaCache[std::distance(cache, p)] = nullptr;
+	auto p = std::find(std::begin(d->LastAddedAreaCache), std::end(d->LastAddedAreaCache), area);
+	if (p != std::end(d->LastAddedAreaCache)) {
+		*p = nullptr;
 	}
 
 	// If splitter has more than 1 widgets, we are finished and can leave


### PR DESCRIPTION
`CDockContainerWidget::removeDockArea` currently checks if `std::find` returns `nullptr` – that should never be the case, it returns `last` if the element was not found. Because of this, `LastAddedAreaCache[5]` might get overwritten, which is out of range.