### PR TITLE
Fixed overlay appearance when the Composite extension is not available

### DIFF
--- a/src/DockOverlay.cpp
+++ b/src/DockOverlay.cpp
@@ -41,6 +41,12 @@
 
 #include <iostream>
 
+// Bu default, the docking functionality requires Composite extension
+// to be available on a Linux system to properly draw semi-transparent
+// overlay. But, if the Composite extension is not available the generic
+// Qt widget functionality can be used. Uncomment it to enable it.
+#define ADS_USE_CHILD_WIDGET_OVERLAY
+
 namespace ads
 {
 
@@ -333,15 +339,22 @@ CDockOverlay::CDockOverlay(QWidget* parent, eMode Mode) :
 {
 	d->Mode = Mode;
 	d->Cross = new CDockOverlayCross(this);
+
+    setWindowTitle("DockOverlay");
+
+#if !defined(ADS_USE_CHILD_WIDGET_OVERLAY)
+
 #ifdef Q_OS_LINUX
 	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
 #else
 	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
 #endif
+
 	setWindowOpacity(1);
-	setWindowTitle("DockOverlay");
 	setAttribute(Qt::WA_NoSystemBackground);
-	setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_TranslucentBackground);
+
+#endif
 
 	d->Cross->setVisible(false);
 	setVisible(false);
@@ -432,11 +445,36 @@ DockWidgetArea CDockOverlay::showOverlay(QWidget* target)
 
 	// Move it over the target.
 	resize(target->size());
-	QPoint TopLeft = target->mapToGlobal(target->rect().topLeft());
-	move(TopLeft);
-	show();
-	d->Cross->updatePosition();
+
+#ifdef ADS_USE_CHILD_WIDGET_OVERLAY
+
+    QPoint TopLeft = QPoint(0, 0);
+
+    // TODO: redesign this stuff
+    if (d->Mode != CDockOverlay::ModeContainerOverlay)
+    {
+        const QPoint pt = target->mapToGlobal(QPoint(0, 0));
+
+        TopLeft = parentWidget() ?
+                    parentWidget()->mapFromGlobal(pt) :
+                    mapFromGlobal(pt);
+    }
+
+    move(TopLeft);
+    show();
+    raise();
+
+#else
+
+    const QPoint TopLeft = target->mapToGlobal(target->rect().topLeft());
+    move(TopLeft);
+    show();
+
+#endif
+
+    d->Cross->updatePosition();
 	d->Cross->updateOverlayIcons();
+
 	return dropAreaUnderCursor();
 }
 
@@ -470,6 +508,18 @@ bool CDockOverlay::dropPreviewEnabled() const
 void CDockOverlay::paintEvent(QPaintEvent* event)
 {
 	Q_UNUSED(event);
+
+#if 0
+    // Some debug stuff
+    {
+        if (d->Mode == CDockOverlay::ModeDockAreaOverlay)
+        {
+            QPainter pnt(this);
+            pnt.fillRect(rect(), QBrush(Qt::yellow, Qt::DiagCrossPattern));
+        }
+    }
+#endif
+
 	// Draw rect based on location
 	if (!d->DropPreviewEnabled)
 	{
@@ -518,7 +568,12 @@ QRect CDockOverlay::dropOverlayRect() const
 void CDockOverlay::showEvent(QShowEvent* e)
 {
 	d->Cross->show();
-	QFrame::showEvent(e);
+
+#ifdef ADS_USE_CHILD_WIDGET_OVERLAY
+    d->Cross->raise();
+#endif
+
+    QFrame::showEvent(e);
 }
 
 
@@ -528,7 +583,6 @@ void CDockOverlay::hideEvent(QHideEvent* e)
 	d->Cross->hide();
 	QFrame::hideEvent(e);
 }
-
 
 //============================================================================
 bool CDockOverlay::event(QEvent *e)
@@ -590,17 +644,27 @@ QPoint DockOverlayCrossPrivate::areaGridPosition(const DockWidgetArea area)
 
 //============================================================================
 CDockOverlayCross::CDockOverlayCross(CDockOverlay* overlay) :
+#ifdef ADS_USE_CHILD_WIDGET_OVERLAY
+    QWidget(overlay),
+#else
 	QWidget(overlay->parentWidget()),
+#endif
 	d(new DockOverlayCrossPrivate(this))
 {
 	d->DockOverlay = overlay;
+
+    setWindowTitle("DockOverlayCross");
+
+#if !defined(ADS_USE_CHILD_WIDGET_OVERLAY)
+
 #ifdef Q_OS_LINUX
 	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
 #else
 	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
 #endif
-	setWindowTitle("DockOverlayCross");
 	setAttribute(Qt::WA_TranslucentBackground);
+
+#endif
 
 	d->GridLayout = new QGridLayout();
 	d->GridLayout->setSpacing(0);
@@ -639,10 +703,11 @@ void CDockOverlayCross::setupOverlayCross(CDockOverlay::eMode Mode)
 //============================================================================
 void CDockOverlayCross::updateOverlayIcons()
 {
-	if (windowHandle()->devicePixelRatio() == d->LastDevicePixelRatio)
-	{
-		return;
-	}
+    if (windowHandle())
+    {
+        if (windowHandle()->devicePixelRatio() == d->LastDevicePixelRatio)
+            return;
+    }
 
 	for (auto Widget : d->DropIndicatorWidgets)
 	{
@@ -761,16 +826,26 @@ void CDockOverlayCross::showEvent(QShowEvent*)
 	this->updatePosition();
 }
 
-
 //============================================================================
 void CDockOverlayCross::updatePosition()
 {
 	resize(d->DockOverlay->size());
-	QPoint TopLeft = d->DockOverlay->pos();
-	QPoint Offest((this->width() - d->DockOverlay->width()) / 2,
-		(this->height() - d->DockOverlay->height()) / 2);
-	QPoint CrossTopLeft = TopLeft - Offest;
-	move(CrossTopLeft);
+
+#ifdef ADS_USE_CHILD_WIDGET_OVERLAY
+
+    move(QPoint(
+            (width()  - d->DockOverlay->width())  / 2,
+            (height() - d->DockOverlay->height()) / 2));
+
+#else
+
+    const QPoint TopLeft = d->DockOverlay->pos();
+    const QPoint Offest((this->width() - d->DockOverlay->width()) / 2,
+        (this->height() - d->DockOverlay->height()) / 2);
+    const QPoint CrossTopLeft = TopLeft - Offest;
+    move(CrossTopLeft);
+
+#endif
 }
 
 

--- a/src/DockOverlay.cpp
+++ b/src/DockOverlay.cpp
@@ -41,12 +41,6 @@
 
 #include <iostream>
 
-// Bu default, the docking functionality requires Composite extension
-// to be available on a Linux system to properly draw semi-transparent
-// overlay. But, if the Composite extension is not available the generic
-// Qt widget functionality can be used. Uncomment it to enable it.
-#define ADS_USE_CHILD_WIDGET_OVERLAY
-
 namespace ads
 {
 

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -546,7 +546,15 @@ void FloatingDockContainerPrivate::updateDropOverlays(const QPoint &GlobalPos)
 		return;
 	}
 
-	int VisibleDockAreas = TopContainer->visibleDockAreaCount();
+#ifdef ADS_USE_CHILD_WIDGET_OVERLAY
+    // Reparent overlay widgets. Because the overlay widget's parent is
+    // the corresponding top level window (indirectly) then it should
+    // be reparented when we try to dock into another top level window.
+    ContainerOverlay->setParent(TopContainer);
+    DockAreaOverlay->setParent(TopContainer);
+#endif
+
+    int VisibleDockAreas = TopContainer->visibleDockAreaCount();
 	ContainerOverlay->setAllowedAreas(
 	    VisibleDockAreas > 1 ? OuterDockAreas : AllDockAreas);
 	DockWidgetArea ContainerArea = ContainerOverlay->showOverlay(TopContainer);
@@ -782,10 +790,10 @@ void CFloatingDockContainer::closeEvent(QCloseEvent *event)
 void CFloatingDockContainer::hideEvent(QHideEvent *event)
 {
 	Super::hideEvent(event);
-    if (event->spontaneous())
-    {
-        return;
-    }
+	if (event->spontaneous())
+	{
+		return;
+	}
 
     // Prevent toogleView() events during restore state
     if (d->DockManager->isRestoringState())
@@ -810,10 +818,10 @@ void CFloatingDockContainer::showEvent(QShowEvent *event)
 {
 	Super::showEvent(event);
 #ifdef Q_OS_LINUX
-    if (CDockManager::testConfigFlag(CDockManager::FocusHighlighting))
-    {
-        this->window()->activateWindow();
-    }
+	if (CDockManager::testConfigFlag(CDockManager::FocusHighlighting))
+	{
+		this->window()->activateWindow();
+	}
 #endif
 }
 

--- a/src/FloatingDragPreview.cpp
+++ b/src/FloatingDragPreview.cpp
@@ -119,6 +119,14 @@ void FloatingDragPreviewPrivate::updateDropOverlays(const QPoint &GlobalPos)
 		return;
 	}
 
+#ifdef ADS_USE_CHILD_WIDGET_OVERLAY
+    // Reparent overlay widgets. Because the overlay widget's parent is
+    // the corresponding top level window (indirectly) then it should
+    // be reparented when we try to dock into another top level window.
+    ContainerOverlay->setParent(TopContainer);
+    DockAreaOverlay->setParent(TopContainer);
+#endif
+
 	int VisibleDockAreas = TopContainer->visibleDockAreaCount();
 	ContainerOverlay->setAllowedAreas(
 	    VisibleDockAreas > 1 ? OuterDockAreas : AllDockAreas);

--- a/src/ads_globals.h
+++ b/src/ads_globals.h
@@ -262,5 +262,11 @@ void repolishStyle(QWidget* w, eRepolishChildOptions Options = RepolishIgnoreChi
 } // namespace internal
 } // namespace ads
 
+// Bu default, the docking functionality requires Composite extension
+// to be available on a Linux system to properly draw semi-transparent
+// overlay. But, if the Composite extension is not available the generic
+// Qt widget functionality can be used. Uncomment it to enable it.
+#define ADS_USE_CHILD_WIDGET_OVERLAY
+
 //---------------------------------------------------------------------------
 #endif // ads_globalsH


### PR DESCRIPTION
Hi,

Here you go!

DockOverlay is created as a direct child widget of DockManager. It started to work OK on Ubuntu 16+. I will also check on CentOS next week. Thanks.