### PR TITLE
Small bug fixes

### DIFF
--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -286,6 +286,8 @@ void CDockWidget::setWidget(QWidget* widget, eInsertMode InsertMode)
 
 	d->Widget = widget;
 	d->Widget->setProperty("dockWidgetContent", true);
+
+	internal::repolishStyle(widget, internal::RepolishDirectChildren);
 }
 
 

--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -50,6 +50,8 @@
 #include "DockOverlay.h"
 #include "DockManager.h"
 #include "IconProvider.h"
+#include "DockAreaTitleBar.h"
+#include "DockAreaTabBar.h"
 
 #include <iostream>
 
@@ -600,6 +602,8 @@ void CDockWidgetTab::setVisible(bool visible)
 void CDockWidgetTab::setText(const QString& title)
 {
 	d->TitleLabel->setText(title);
+	if (d->DockArea)
+		d->DockArea->titleBar()->tabBar()->updateGeometry();
 }
 
 


### PR DESCRIPTION
This change fixes a bug where calling setWindowTitle on a CDockWidget to change the title to a longer name elides the tab label text until another event causes the tab to be resized.