### PR TITLE
Added option to fix resizing of DockWidget and option to hide DockAre…

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -250,6 +250,7 @@ struct DockAreaWidgetPrivate
 	CDockAreaTitleBar*	TitleBar		= nullptr;
 	CDockManager*		DockManager		= nullptr;
 	bool UpdateTitleBarButtons = false;
+    bool TitleBarVisible = true;
 	DockWidgetAreas		AllowedAreas	= AllDockAreas;
 	QSize MinSizeHint;
 
@@ -745,7 +746,7 @@ void CDockAreaWidget::updateTitleBarVisibility()
 
 	if (d->TitleBar)
 	{
-		bool Hidden = Container->hasTopLevelDockWidget() && (Container->isFloating()
+        bool Hidden = !d->TitleBarVisible || Container->hasTopLevelDockWidget() && (Container->isFloating()
 			|| CDockManager::testConfigFlag(CDockManager::HideSingleCentralWidgetTitleBar));
 		d->TitleBar->setVisible(!Hidden);
 	}
@@ -900,6 +901,34 @@ CDockAreaTitleBar* CDockAreaWidget::titleBar() const
 	return d->TitleBar;
 }
 
+//============================================================================
+void CDockAreaWidget::setTitleBarVisible(bool visible)
+{
+    if(visible==d->TitleBarVisible)
+    {
+        return;
+    }
+
+    d->TitleBarVisible=visible;
+    updateTitleBarVisibility();
+}
+
+//============================================================================
+bool CDockAreaWidget::isTitleBarVisible()
+{
+    return d->TitleBarVisible;
+}
+
+//============================================================================
+CDockWidget::eResizeMode CDockAreaWidget::resizeMode()
+{
+    auto OpenDockWidgets = openedDockWidgets();
+    if(OpenDockWidgets.count() != 1)
+    {
+        return CDockWidget::eResizeMode::ResizeAll;
+    }
+    return OpenDockWidgets[0]->resizeMode();
+}
 
 //============================================================================
 QSize CDockAreaWidget::minimumSizeHint() const

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -277,6 +277,21 @@ public:
 	 */
 	CDockAreaTitleBar* titleBar() const;
 
+    /**
+      * Sets titleBar visible or hidden
+      */
+    void setTitleBarVisible(bool visible);
+
+    /**
+     * Returns true if title bar for this area is visible.
+     */
+    bool isTitleBarVisible();
+
+	/**
+	 * Returns resize mode for the dock area widget based on visible dock widgets.
+	 */
+    CDockWidget::eResizeMode resizeMode();
+
 public slots:
 	/**
 	 * This activates the tab for the given tab index.

--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -707,15 +707,18 @@ void DockContainerWidgetPrivate::moveToNewSection(QWidget* Widget, CDockAreaWidg
 
 
 //============================================================================
-void DockContainerWidgetPrivate::updateSplitterHandles(QSplitter* splitter)
+void DockContainerWidgetPrivate::updateSplitterHandles( QSplitter* splitter )
 {
-    for (int index = 1; index<splitter->count(); index++)
-    {
-        CDockAreaWidget* area1 = dynamic_cast<CDockAreaWidget*>(splitter->widget(index-1));
-        CDockAreaWidget* area2 = dynamic_cast<CDockAreaWidget*>(splitter->widget(index));
-        bool handleDisabled = isAreaFixedInSplitter(splitter, area1) || isAreaFixedInSplitter(splitter, area2 );
-        splitter->handle(index)->setEnabled(!handleDisabled);
-    }
+	if( splitter )
+	{
+		for( int index = 1; index < splitter->count(); index++ )
+		{
+			CDockAreaWidget* area1 = dynamic_cast< CDockAreaWidget* >( splitter->widget( index - 1 ) );
+			CDockAreaWidget* area2 = dynamic_cast< CDockAreaWidget* >( splitter->widget( index ) );
+			bool handleDisabled = isAreaFixedInSplitter( splitter, area1 ) || isAreaFixedInSplitter( splitter, area2 );
+			splitter->handle( index )->setEnabled( !handleDisabled );
+		}
+	}
 }
 
 
@@ -1427,6 +1430,7 @@ void CDockContainerWidget::removeDockArea(CDockAreaWidget* area)
 	}
 
 	delete Splitter;
+	Splitter = nullptr;
 
 emitAndExit:
     updateSplitterHandles(Splitter);

--- a/src/DockContainerWidget.h
+++ b/src/DockContainerWidget.h
@@ -134,16 +134,16 @@ protected:
 	 */
 	CDockAreaWidget* lastAddedDockAreaWidget(DockWidgetArea area) const;
 
-	/**
-	 * If hasSingleVisibleDockWidget() returns true, this function returns the
-	 * one and only visible dock widget. Otherwise it returns a nullptr.
-	 */
-	CDockWidget* topLevelDockWidget() const;
+    /**
+     * If hasSingleVisibleDockWidget() returns true, this function returns the
+     * one and only visible dock widget. Otherwise it returns a nullptr.
+     */
+    CDockWidget* topLevelDockWidget() const;
 
-	/**
-	 * Returns the top level dock area.
-	 */
-	CDockAreaWidget* topLevelDockArea() const;
+    /**
+     * Returns the top level dock area.
+     */
+    CDockAreaWidget* topLevelDockArea() const;
 
     /**
      * This function returns a list of all dock widgets in this floating widget.
@@ -154,6 +154,12 @@ protected:
      * dock widgets returned from all dock areas.
      */
     QList<CDockWidget*> dockWidgets() const;
+
+	/**
+	 * This finction forces the dock container widget to update handles of splitters
+	 * based on resize modes of dock widgets aontained in the container.
+	 */
+    void updateSplitterHandles(QSplitter* splitter);
 
 public:
 	/**

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -84,6 +84,7 @@ struct DockWidgetPrivate
 	bool IsFloatingTopLevel = false;
 	QList<QAction*> TitleBarActions;
 	CDockWidget::eMinimumSizeHintMode MinimumSizeHintMode = CDockWidget::MinimumSizeHintFromDockWidget;
+    CDockWidget::eResizeMode ResizeMode = CDockWidget::ResizeAll;
 
 	/**
 	 * Private data constructor
@@ -458,6 +459,19 @@ void CDockWidget::setToggleViewActionMode(eToggleViewActionMode Mode)
 void CDockWidget::setMinimumSizeHintMode(eMinimumSizeHintMode Mode)
 {
 	d->MinimumSizeHintMode = Mode;
+}
+
+
+//============================================================================
+CDockWidget::eResizeMode CDockWidget::resizeMode()
+{
+    return d->ResizeMode;
+}
+
+//============================================================================
+void CDockWidget::setResizeMode(eResizeMode Mode)
+{
+    d->ResizeMode = Mode;
 }
 
 

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -208,6 +208,23 @@ public:
 
 
     /**
+     * The mode of resize that configures in which direction a DockWidget can be resized.
+     * By default a DockWidget can be resized in both directions (horizontal and vertical).
+     * If set to resize only horizontal or only vertical or not to resize at all the DockWidget 
+     * if being the only DockWidget in an DockAreaWidget will cause the corresponding
+     * splitter handle to be disabled and will not allow the DockWidget to resize in the respective direction.
+     */
+    enum eResizeMode
+    {
+        ResizeHorizontal = 0x01,///< dock widget can stretch forizaontally
+        ResizeVertical = 0x02,///< dock widget can stretch vertically
+        ResizeAll = ResizeHorizontal | ResizeVertical,
+        NoResize = 0x00
+    };
+    Q_DECLARE_FLAGS(eResizeModes, eResizeMode)
+
+
+    /**
      * This mode configures the behavior of the toggle view action.
      * If the mode if ActionModeToggle, then the toggle view action is
      * a checkable action to show / hide the dock widget. If the mode
@@ -359,6 +376,19 @@ public:
      * \see eMinimumSizeHintMode for a detailed description
      */
     void setMinimumSizeHintMode(eMinimumSizeHintMode Mode);
+    
+    /**
+     * Returns the resize mode of the DockWidget defining 
+     * in which direction the DockWidget can be resized (if the only DockWidget in 
+     * DockAreaWidget)
+     */
+    eResizeMode resizeMode();
+
+    /**
+     * Sets the dock widget resize mode defining in which direction the dock widget
+     * can be resized if it is the only dock widget in it's dock area widget.
+     */
+    void setResizeMode(eResizeMode Mode);
 
     /**
      * Sets the dock widget icon that is shown in tabs and in toggle view


### PR DESCRIPTION
…aWidget titlebar.

Added option to set DockWidget resize direction. By default the DockWidget can resize in both directions (horizontal and vertical). If the direction is however limited to only one or none and the DockWidget is the only visible dock widget in it's dock area widget, the respective splitter handle will be disabled (if the splitter direction is the same as the non resizing direction of the dock widget). Also added option to hide Titlebar of a DockAreaWidget completely.