### PR TITLE
Added possibility to hide titlebar when only one widget is in the area

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -251,6 +251,7 @@ struct DockAreaWidgetPrivate
 	CDockManager*		DockManager		= nullptr;
 	bool UpdateTitleBarButtons = false;
 	DockWidgetAreas		AllowedAreas	= AllDockAreas;
+	bool HideSingleWidgetTitleBar		= false;
 	QSize MinSizeHint;
 
 	/**
@@ -745,8 +746,14 @@ void CDockAreaWidget::updateTitleBarVisibility()
 
 	if (d->TitleBar)
 	{
-		bool Hidden = Container->hasTopLevelDockWidget() && (Container->isFloating()
-			|| CDockManager::testConfigFlag(CDockManager::HideSingleCentralWidgetTitleBar));
+		bool Hidden = (
+					Container->hasTopLevelDockWidget() && (Container->isFloating()
+						|| CDockManager::testConfigFlag(CDockManager::HideSingleCentralWidgetTitleBar))
+					)
+				||
+					(
+						d->HideSingleWidgetTitleBar && dockWidgetsCount() == 1
+					);
 		d->TitleBar->setVisible(!Hidden);
 	}
 }
@@ -859,6 +866,14 @@ DockWidgetAreas CDockAreaWidget::allowedAreas() const
 {
 	return d->AllowedAreas;
 }
+
+//============================================================================
+void CDockAreaWidget::setHideSingleWidgetTitleBar(bool hide)
+{
+	d->HideSingleWidgetTitleBar = hide;
+	updateTitleBarVisibility();
+}
+
 
 //============================================================================
 QAbstractButton* CDockAreaWidget::titleBarButton(TitleBarButton which) const

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -273,6 +273,12 @@ public:
 	DockWidgetAreas allowedAreas() const;
 
 	/**
+	 * Will hide the titlebar when set to true and there is only one child in this area.
+	 */
+	void setHideSingleWidgetTitleBar(bool hide);
+
+
+	/**
 	 * Returns the title bar of this dock area
 	 */
 	CDockAreaTitleBar* titleBar() const;


### PR DESCRIPTION
Implements #207

This simple PR adds the `setHideSingleWidgetTitleBar` function to `CDockAreaWidget` to make it possible to hide the titlebar when only one child is in the area.
This allows a central widget (for example) to be displayed without title bar while at the same time allows to drop other widgets on the central widget which would then show the title bar again.
If this is not wanted simply disallowing docking onto the central widget does the trick.

This behavior is disabled by default.