### PR TITLE
Add maximize button to FloatingWidgetTitleBar [Revived 2]

### DIFF
--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -830,10 +830,15 @@ void CFloatingDockContainer::startFloating(const QPoint &DragStartMousePos,
 #ifndef Q_OS_LINUX
 	Q_UNUSED(MouseEventHandler)
 #endif
+#ifdef Q_OS_LINUX
     if (!isMaximized()) {
         resize(Size);
         d->DragStartMousePosition = DragStartMousePos;
     }
+#else
+    resize(Size);
+    d->DragStartMousePosition = DragStartMousePos;
+#endif
     d->setState(DragState);
 #ifdef Q_OS_LINUX
 	if (DraggingFloatingWidget == DragState)
@@ -846,10 +851,15 @@ void CFloatingDockContainer::startFloating(const QPoint &DragStartMousePos,
 		}
 	}
 #endif
+#ifdef Q_OS_LINUX
     if (!isMaximized()) {
         moveFloating();
     }
 	show();
+#else
+    moveFloating();
+	show();
+#endif
 }
 
 //============================================================================
@@ -1118,6 +1128,7 @@ void CFloatingDockContainer::onMaximizeRequest()
         auto maxX = qMin(screenRect.right(), widgetRect.right());
         auto maxY = qMin(screenRect.bottom(), widgetRect.bottom());
         auto area = minX < maxX && minY < maxY ? (maxX - minX) * (maxY - minY) : 0;
+        qDebug() << screenRect << "area" << area << screen->availableVirtualGeometry();
         if (area > maxArea)
         {
             maxArea = area;
@@ -1132,6 +1143,10 @@ void CFloatingDockContainer::onMaximizeRequest()
     // get current windows state, if it is maximized and moved or not
     if (geometry().size() == currentScreen->availableGeometry().size())
     {
+        if (d->NormalizedGeometry.width() == 0) {
+            d->NormalizedGeometry = geometry().adjusted(geometry().width()/3, geometry().height()/3,
+                                                        -geometry().width()/3, -geometry().height()/3);
+        }
         setGeometry(d->NormalizedGeometry);
         d->TitleBar->setMaximizedIcon(false);
         d->IsMaximized = false;
@@ -1150,16 +1165,29 @@ void CFloatingDockContainer::onMaximizeRequest()
     {
         auto cursorPos = QCursor::pos();
         qDebug() << "pos" << cursorPos;
-        auto screen = QGuiApplication::screenAt(QCursor::pos());
-        if (d->IsMaximized) {
+#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
+        QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
+#else
+        QScreen *screen = nullptr;
+        for (const auto &sc : QGuiApplication::screens()) {
+            if (sc->geometry().contains(cursorPos)) {
+                screen = sc;
+            }
+        }
+#endif
+        if (screen && d->IsMaximized) {
+            if (d->NormalizedGeometry.width() == 0) {
+                d->NormalizedGeometry = geometry().adjusted(geometry().width()/3, geometry().height()/3,
+                                                            -geometry().width()/3, -geometry().height()/3);
+            }
             auto screenGeometry = screen->availableGeometry();
             QRect r = QRect(cursorPos.x()
                     -(cursorPos.x() - screenGeometry.left())/(double)screenGeometry.width() * d->NormalizedGeometry.width(),
                             cursorPos.y(), d->NormalizedGeometry.width(),d->NormalizedGeometry.height());
             qDebug() << "rect"<<r;
-            move(r.left(), r.top());
-            resize(r.width(), r.height());
+            setGeometry(r);
             d->IsMaximized = false;
+            d->TitleBar->setMaximizedIcon(true);
             qDebug() << "geometry" << geometry();
         }
     }

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -605,12 +605,12 @@ CFloatingDockContainer::CFloatingDockContainer(CDockManager *DockManager) :
 
 #ifdef Q_OS_LINUX
     d->TitleBar = new CFloatingWidgetTitleBar(this);
-	setWindowFlag(Qt::Tool, false);
-	setWindowFlag(Qt::Window, true);
     QDockWidget::setWidget(d->DockContainer);
     QDockWidget::setFloating(true);
     QDockWidget::setFeatures(QDockWidget::AllDockWidgetFeatures);
     setTitleBarWidget(d->TitleBar);
+	setWindowFlag(Qt::Tool, false);
+	setWindowFlag(Qt::Window, true);
     connect(d->TitleBar, SIGNAL(closeRequested()), SLOT(close()));
     connect(d->TitleBar, &CFloatingWidgetTitleBar::maximizeRequested,
             this, &CFloatingDockContainer::onMaximizeRequest);

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -1128,7 +1128,6 @@ void CFloatingDockContainer::onMaximizeRequest()
         auto maxX = qMin(screenRect.right(), widgetRect.right());
         auto maxY = qMin(screenRect.bottom(), widgetRect.bottom());
         auto area = minX < maxX && minY < maxY ? (maxX - minX) * (maxY - minY) : 0;
-        qDebug() << screenRect << "area" << area << screen->availableVirtualGeometry();
         if (area > maxArea)
         {
             maxArea = area;
@@ -1153,7 +1152,6 @@ void CFloatingDockContainer::onMaximizeRequest()
     }
     else
     {
-        qDebug() << "maximize";
         d->NormalizedGeometry = geometry();
         d->IsMaximized = true;
         setGeometry(currentScreen->availableGeometry());
@@ -1164,7 +1162,6 @@ void CFloatingDockContainer::onMaximizeRequest()
     void CFloatingDockContainer::dragToNormalize()
     {
         auto cursorPos = QCursor::pos();
-        qDebug() << "pos" << cursorPos;
 #if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
         QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
 #else
@@ -1184,11 +1181,9 @@ void CFloatingDockContainer::onMaximizeRequest()
             QRect r = QRect(cursorPos.x()
                     -(cursorPos.x() - screenGeometry.left())/(double)screenGeometry.width() * d->NormalizedGeometry.width(),
                             cursorPos.y(), d->NormalizedGeometry.width(),d->NormalizedGeometry.height());
-            qDebug() << "rect"<<r;
             setGeometry(r);
             d->IsMaximized = false;
-            d->TitleBar->setMaximizedIcon(true);
-            qDebug() << "geometry" << geometry();
+			d->TitleBar->setMaximizedIcon(false);
         }
     }
 

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -605,7 +605,8 @@ CFloatingDockContainer::CFloatingDockContainer(CDockManager *DockManager) :
 
 #ifdef Q_OS_LINUX
     d->TitleBar = new CFloatingWidgetTitleBar(this);
-    setWindowFlags(windowFlags() | Qt::Tool);
+	setWindowFlag(Qt::Tool, false);
+	setWindowFlag(Qt::Window, true);
     QDockWidget::setWidget(d->DockContainer);
     QDockWidget::setFloating(true);
     QDockWidget::setFeatures(QDockWidget::AllDockWidgetFeatures);
@@ -613,6 +614,7 @@ CFloatingDockContainer::CFloatingDockContainer(CDockManager *DockManager) :
     connect(d->TitleBar, SIGNAL(closeRequested()), SLOT(close()));
     connect(d->TitleBar, &CFloatingWidgetTitleBar::maximizeRequested,
             this, &CFloatingDockContainer::onMaximizeRequest);
+
 #else
 	setWindowFlags(
 	    Qt::Window | Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint);

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -1113,7 +1113,7 @@ void CFloatingDockContainer::onMaximizeRequest()
         auto minY = qMax(screenRect.top(), widgetRect.top());
         auto maxX = qMin(screenRect.right(), widgetRect.right());
         auto maxY = qMin(screenRect.bottom(), widgetRect.bottom());
-        auto area = minX < maxX && minY < maxY ? (maxX - minX) * (maxY * minY) : 0;
+        auto area = minX < maxX && minY < maxY ? (maxX - minX) * (maxY - minY) : 0;
         if (area > maxArea)
         {
             maxArea = area;

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -377,7 +377,6 @@ struct FloatingDockContainerPrivate
 #ifdef Q_OS_LINUX
     QWidget* MouseEventHandler = nullptr;
     CFloatingWidgetTitleBar* TitleBar = nullptr;
-    QRect LastGeometry;
 #endif
 
 	/**
@@ -612,7 +611,6 @@ CFloatingDockContainer::CFloatingDockContainer(CDockManager *DockManager) :
     QDockWidget::setFloating(true);
     QDockWidget::setFeatures(QDockWidget::AllDockWidgetFeatures);
     setTitleBarWidget(d->TitleBar);
-    d->LastGeometry = geometry();
     connect(d->TitleBar, SIGNAL(closeRequested()), SLOT(close()));
     connect(d->TitleBar, &CFloatingWidgetTitleBar::maximizeRequested,
             this, &CFloatingDockContainer::onMaximizeRequest);
@@ -1126,15 +1124,14 @@ void CFloatingDockContainer::onMaximizeRequest()
     }
     ADS_PRINT("CFloatingDockContainer::onMaximizeRequest() current screen: " + currentScreen->name());
     // get current windows state, if it is maximized and moved or not
-    if (geometry().size() == currentScreen->availableGeometry().size())
+    if (windowState() == Qt::WindowMaximized)
     {
-        setGeometry(d->LastGeometry);
+        setWindowState(Qt::WindowNoState);
         d->TitleBar->setMaximizedIcon(false);
     }
     else
     {
-        d->LastGeometry = geometry();
-        setGeometry(currentScreen->availableGeometry());
+        setWindowState(Qt::WindowMaximized);
         d->TitleBar->setMaximizedIcon(true);
     }
 }

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -53,6 +53,7 @@
 #endif
 #endif
 #ifdef Q_OS_LINUX
+#include <QScreen>
 #include "linux/FloatingWidgetTitleBar.h"
 #include <xcb/xcb.h>
 #endif
@@ -376,6 +377,7 @@ struct FloatingDockContainerPrivate
 #ifdef Q_OS_LINUX
     QWidget* MouseEventHandler = nullptr;
     CFloatingWidgetTitleBar* TitleBar = nullptr;
+    QRect LastGeometry;
 #endif
 
 	/**
@@ -610,7 +612,10 @@ CFloatingDockContainer::CFloatingDockContainer(CDockManager *DockManager) :
     QDockWidget::setFloating(true);
     QDockWidget::setFeatures(QDockWidget::AllDockWidgetFeatures);
     setTitleBarWidget(d->TitleBar);
+    d->LastGeometry = geometry();
     connect(d->TitleBar, SIGNAL(closeRequested()), SLOT(close()));
+    connect(d->TitleBar, &CFloatingWidgetTitleBar::maximizeRequested,
+            this, &CFloatingDockContainer::onMaximizeRequest);
 #else
 	setWindowFlags(
 	    Qt::Window | Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint);
@@ -989,7 +994,6 @@ void CFloatingDockContainer::finishDragging()
    d->titleMouseReleaseEvent();
 }
 
-
 #ifdef Q_OS_MACOS
 //============================================================================
 bool CFloatingDockContainer::event(QEvent *e)
@@ -1089,6 +1093,50 @@ void CFloatingDockContainer::moveEvent(QMoveEvent *event)
 	}
 
 
+}
+#endif
+
+#ifdef Q_OS_LINUX
+void CFloatingDockContainer::onMaximizeRequest()
+{
+    ADS_PRINT("CFloatingDockContainer::onMaximizeRequest()");
+    QRect screenRect;
+    QRect widgetRect;
+    const QScreen *currentScreen = nullptr;
+    int maxArea = 0;
+    // get current screen
+    for (const auto &screen : QGuiApplication::screens())
+    {
+        screenRect = screen->geometry();
+        widgetRect = this->geometry();
+        auto minX = qMax(screenRect.left(), widgetRect.left());
+        auto minY = qMax(screenRect.top(), widgetRect.top());
+        auto maxX = qMin(screenRect.right(), widgetRect.right());
+        auto maxY = qMin(screenRect.bottom(), widgetRect.bottom());
+        auto area = minX < maxX && minY < maxY ? (maxX - minX) * (maxY * minY) : 0;
+        if (area > maxArea)
+        {
+            maxArea = area;
+            currentScreen = screen;
+        }
+    }
+    if (!currentScreen)
+    {
+        return;
+    }
+    ADS_PRINT("CFloatingDockContainer::onMaximizeRequest() current screen: " + currentScreen->name());
+    // get current windows state, if it is maximized and moved or not
+    if (geometry().size() == currentScreen->availableGeometry().size())
+    {
+        setGeometry(d->LastGeometry);
+        d->TitleBar->setMaximizedIcon(false);
+    }
+    else
+    {
+        d->LastGeometry = geometry();
+        setGeometry(currentScreen->availableGeometry());
+        d->TitleBar->setMaximizedIcon(true);
+    }
 }
 #endif
 

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -251,13 +251,19 @@ public:
 
 #ifdef Q_OS_LINUX
     /**
-     * This is a function respond to FloatingWidgetTitleBar::maximizeRequest()
-     * maximize or normalize the container size.
+	 * This is a function that responds to FloatingWidgetTitleBar::maximizeRequest()
+	 * Maximize or normalize the container size.
      */
     void onMaximizeRequest();
 
+	/**
+	 * Normalize / resize the window size when dragging a maximized window.
+	 */
     void dragToNormalize();
 
+	/**
+	 * Returns if the window is currently maximized or not.
+	 */
     bool isMaximized() const;
 #endif
 

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -255,6 +255,7 @@ public:
      * maximize or normalize the container size.
      */
     void onMaximizeRequest();
+
     void dragToNormalize();
 
     bool isMaximized() const;

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -248,6 +248,15 @@ public:
      * function of the internal container widget.
      */
     QList<CDockWidget*> dockWidgets() const;
+
+#ifdef Q_OS_LINUX
+    /**
+     * This is a function respond to FloatingWidgetTitleBar::maximizeRequest()
+     * maximize or normalize the container size.
+     */
+    void onMaximizeRequest();
+#endif
+
 }; // class FloatingDockContainer
 }
  // namespace ads

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -255,6 +255,9 @@ public:
      * maximize or normalize the container size.
      */
     void onMaximizeRequest();
+    void dragToNormalize();
+
+    bool isMaximized() const;
 #endif
 
 }; // class FloatingDockContainer

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -257,9 +257,17 @@ public:
     void onMaximizeRequest();
 
 	/**
-	 * Normalize / resize the window size when dragging a maximized window.
+	 * Normalize (Unmaximize) the window.
+	 *	fixGeometry fixes a "bug" in QT where immediately after calling showNormal
+	 *	geometry is not set properly.
+	 *	Set this true when moving the window immediately after normalizing.
 	 */
-    void dragToNormalize();
+	void showNormal(bool fixGeometry=false);
+
+	/**
+	 * Maximizes the window.
+	 */
+	void showMaximized();
 
 	/**
 	 * Returns if the window is currently maximized or not.

--- a/src/linux/FloatingWidgetTitleBar.cpp
+++ b/src/linux/FloatingWidgetTitleBar.cpp
@@ -178,6 +178,7 @@ void CFloatingWidgetTitleBar::mouseMoveEvent(QMouseEvent *ev)
 	// move floating window
 	if (DraggingFloatingWidget == d->DragState)
 	{
+	    d->FloatingWidget->dragToNormalize();
 		d->FloatingWidget->moveFloating();
 		Super::mouseMoveEvent(ev);
 		return;

--- a/src/linux/FloatingWidgetTitleBar.cpp
+++ b/src/linux/FloatingWidgetTitleBar.cpp
@@ -46,6 +46,7 @@ namespace ads
 
 using tTabLabel = CElidingLabel;
 using tCloseButton = QToolButton;
+using tMaximizeButton  = QToolButton;
 
 /**
  * @brief Private data class of public interface CFloatingWidgetTitleBar
@@ -56,6 +57,7 @@ struct FloatingWidgetTitleBarPrivate
 	QLabel *IconLabel = nullptr;
 	tTabLabel *TitleLabel;
 	tCloseButton *CloseButton = nullptr;
+    tMaximizeButton* MaximizeButton = nullptr;
 	CFloatingDockContainer *FloatingWidget = nullptr;
 	eDragState DragState = DraggingInactive;
 
@@ -83,6 +85,10 @@ void FloatingWidgetTitleBarPrivate::createLayout()
 	CloseButton->setObjectName("floatingTitleCloseButton");
     CloseButton->setAutoRaise(true);
 
+	MaximizeButton = new tMaximizeButton();
+    MaximizeButton->setObjectName("floatingTitleMaximizeButton");
+	MaximizeButton->setAutoRaise(true);
+
 	// The standard icons do does not look good on high DPI screens
 	QIcon CloseIcon;
 	QPixmap normalPixmap = _this->style()->standardPixmap(
@@ -97,6 +103,12 @@ void FloatingWidgetTitleBarPrivate::createLayout()
 	CloseButton->setFocusPolicy(Qt::NoFocus);
 	_this->connect(CloseButton, SIGNAL(clicked()), SIGNAL(closeRequested()));
 
+    _this->setMaximizedIcon(false);
+    MaximizeButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    MaximizeButton->setVisible(true);
+    MaximizeButton->setFocusPolicy(Qt::NoFocus);
+    _this->connect(MaximizeButton, &QPushButton::clicked, _this, &CFloatingWidgetTitleBar::maximizeRequested);
+
 	QFontMetrics fm(TitleLabel->font());
 	int Spacing = qRound(fm.height() / 4.0);
 
@@ -107,6 +119,7 @@ void FloatingWidgetTitleBarPrivate::createLayout()
 	_this->setLayout(Layout);
 	Layout->addWidget(TitleLabel, 1);
 	Layout->addSpacing(Spacing);
+    Layout->addWidget(MaximizeButton);
 	Layout->addWidget(CloseButton);
 	Layout->setAlignment(Qt::AlignCenter);
 
@@ -186,11 +199,43 @@ void CFloatingWidgetTitleBar::setTitle(const QString &Text)
 	d->TitleLabel->setText(Text);
 }
 
-
 //============================================================================
 void CFloatingWidgetTitleBar::updateStyle()
 {
     internal::repolishStyle(this, internal::RepolishDirectChildren);
+}
+
+void CFloatingWidgetTitleBar::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    if (event->buttons() & Qt::LeftButton)
+    {
+        emit maximizeRequested();
+        event->accept();
+    }
+    else
+    {
+        QWidget::mouseDoubleClickEvent(event);
+    }
+}
+
+void CFloatingWidgetTitleBar::setMaximizedIcon(bool maximized)
+{
+    if (maximized)
+    {
+        QIcon normalIcon;
+        auto normalPixmap = this->style()->standardPixmap(QStyle::SP_TitleBarNormalButton, 0, d->MaximizeButton);
+        normalIcon.addPixmap(normalPixmap, QIcon::Normal);
+        normalIcon.addPixmap(internal::createTransparentPixmap(normalPixmap, 0.25), QIcon::Disabled);
+        d->MaximizeButton->setIcon(normalIcon);
+    }
+    else
+    {
+        QIcon MaxIcon;
+        auto maxPixmap = this->style()->standardPixmap(QStyle::SP_TitleBarMaxButton, 0, d->MaximizeButton);
+        MaxIcon.addPixmap(maxPixmap, QIcon::Normal);
+        MaxIcon.addPixmap(internal::createTransparentPixmap(maxPixmap, 0.25), QIcon::Disabled);
+        d->MaximizeButton->setIcon(MaxIcon);
+    }
 }
 
 } // namespace ads

--- a/src/linux/FloatingWidgetTitleBar.cpp
+++ b/src/linux/FloatingWidgetTitleBar.cpp
@@ -178,7 +178,9 @@ void CFloatingWidgetTitleBar::mouseMoveEvent(QMouseEvent *ev)
 	// move floating window
 	if (DraggingFloatingWidget == d->DragState)
 	{
+#ifdef Q_OS_LINUX
 	    d->FloatingWidget->dragToNormalize();
+#endif
 		d->FloatingWidget->moveFloating();
 		Super::mouseMoveEvent(ev);
 		return;

--- a/src/linux/FloatingWidgetTitleBar.cpp
+++ b/src/linux/FloatingWidgetTitleBar.cpp
@@ -160,7 +160,7 @@ void CFloatingWidgetTitleBar::mouseReleaseEvent(QMouseEvent *ev)
 	d->DragState = DraggingInactive;
     if (d->FloatingWidget)
     {
-        d->FloatingWidget->finishDragging();
+		d->FloatingWidget->finishDragging();
     }
 	Super::mouseReleaseEvent(ev);
 }
@@ -179,7 +179,10 @@ void CFloatingWidgetTitleBar::mouseMoveEvent(QMouseEvent *ev)
 	if (DraggingFloatingWidget == d->DragState)
 	{
 #ifdef Q_OS_LINUX
-	    d->FloatingWidget->dragToNormalize();
+		if(d->FloatingWidget->isMaximized())
+		{
+			d->FloatingWidget->showNormal(true);
+		}
 #endif
 		d->FloatingWidget->moveFloating();
 		Super::mouseMoveEvent(ev);

--- a/src/linux/FloatingWidgetTitleBar.h
+++ b/src/linux/FloatingWidgetTitleBar.h
@@ -55,6 +55,7 @@ protected:
 	virtual void mousePressEvent(QMouseEvent *ev) override;
 	virtual void mouseReleaseEvent(QMouseEvent *ev) override;
 	virtual void mouseMoveEvent(QMouseEvent *ev) override;
+    virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
 
 public:
 	using Super = QWidget;
@@ -80,11 +81,21 @@ public:
      */
     void updateStyle();
 
+	/**
+	 * Change the maximize button icon according to current windows state
+	 */
+    void setMaximizedIcon(bool maximized);
+
 signals:
 	/**
 	 * This signal is emitted, if the close button is clicked.
 	 */
 	void closeRequested();
+
+    /**
+    * This signal is emitted, if the maximize button is clicked.
+    */
+    void maximizeRequested();
 };
 } // namespace ads
 #endif // FLOATINGWIDGETTITLEBAR_H


### PR DESCRIPTION
Continuation from #228

I switched back to using `showNormal` and Co. This simplified the code by a good bit and also allows to benefit from possible future updates in QTs `showNormal` and especially `showMaximize` functions.

Everything seem to be fine, but further tests especially on other window manager might be a good idea.
*Fixed from last state:*
- *Restoring maximized windows now works properly.*
- *Maximized window size should no be more often correct. (QT itself uses workarounds to get this playing nice with X11)*

The only thing i am not really sure about is that i had to remove `setAttribute(Qt::WA_X11NetWmWindowTypeDock, true);` because that broke `showMaximized` for some reason.
I don't see any change on my System tho, but this may be different on other systems .?