### PR TITLE
Persist the HideSingleWidgetTitleBar and AllowedAreas state

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -771,6 +771,8 @@ void CDockAreaWidget::saveState(QXmlStreamWriter& s) const
 	auto CurrentDockWidget = currentDockWidget();
 	QString Name = CurrentDockWidget ? CurrentDockWidget->objectName() : "";
 	s.writeAttribute("Current", Name);
+	s.writeAttribute("AllowedAreas", QString::number(allowedAreas()));
+	s.writeAttribute("HideSingleWidgetTitleBar", QString::number(d->HideSingleWidgetTitleBar));
     ADS_PRINT("CDockAreaWidget::saveState TabCount: " << d->ContentsLayout->count()
             << " Current: " << Name);
 	for (int i = 0; i < d->ContentsLayout->count(); ++i)
@@ -862,6 +864,12 @@ void CDockAreaWidget::setAllowedAreas(DockWidgetAreas areas)
 DockWidgetAreas CDockAreaWidget::allowedAreas() const
 {
 	return d->AllowedAreas;
+}
+
+//============================================================================
+bool CDockAreaWidget::isHideSingleWidgetTitleBar()
+{
+	return d->HideSingleWidgetTitleBar;
 }
 
 //============================================================================

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -279,6 +279,12 @@ public:
 	void setHideSingleWidgetTitleBar(bool hide);
 
 	/**
+	 * Returns if the title bar will be hidden when there is only one
+	 * dock widget in this area
+	 */
+	bool isHideSingleWidgetTitleBar();
+
+	/**
 	 * Returns the title bar of this dock area
 	 */
 	CDockAreaTitleBar* titleBar() const;

--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -935,6 +935,7 @@ bool DockContainerWidgetPrivate::restoreDockArea(CDockingStateReader& s,
 #endif
 
 	QString CurrentDockWidget = s.attributes().value("Current").toString();
+
     ADS_PRINT("Restore NodeDockArea Tabs: " << Tabs << " Current: "
             << CurrentDockWidget);
 
@@ -942,6 +943,12 @@ bool DockContainerWidgetPrivate::restoreDockArea(CDockingStateReader& s,
 	if (!Testing)
 	{
 		DockArea = new CDockAreaWidget(DockManager, _this);
+		if(s.attributes().value("AllowedAreas").length()){
+			DockArea->setAllowedAreas((DockWidgetArea)s.attributes().value("AllowedAreas").toInt());
+		}
+		if(s.attributes().value("HideSingleWidgetTitleBar").length()){
+			DockArea->setHideSingleWidgetTitleBar(s.attributes().value("HideSingleWidgetTitleBar").toInt());
+		}
 	}
 
 	while (s.readNextStartElement())


### PR DESCRIPTION
Currently the `HideSingleWidgetTitleBar` and  `AllowedAreas` state of Areas is lost on loading the state.
This PR fixes this.
Should be backwards compatible without a problem.

I also smuggled in a getter for `HideSingleWidgetTitleBar` which i missed previously.