### PR TITLE
Delete widgets without parents in CDockAreaLayout.

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -87,6 +87,18 @@ public:
 	}
 
 	/**
+	 * Delete widgets without parents in this layout
+	 */
+	~CDockAreaLayout()
+	{
+		for(auto Widget : m_Widgets)
+		{
+			if(!Widget->parent())
+				delete Widget;
+		}
+	}
+
+	/**
 	 * Returns the number of widgets in this layout
 	 */
 	int count() const


### PR DESCRIPTION
Or they will never be deleted.