### PR TITLE
Fixes pack. Parenting, memory leaks, floating widgets deleting.

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -87,18 +87,6 @@ public:
 	}
 
 	/**
-	 * Delete widgets without parents in this layout
-	 */
-	~CDockAreaLayout()
-	{
-		for(auto Widget : m_Widgets)
-		{
-			if(!Widget->parent())
-				delete Widget;
-		}
-	}
-
-	/**
 	 * Returns the number of widgets in this layout
 	 */
 	int count() const
@@ -112,7 +100,6 @@ public:
 	 */
 	void insertWidget(int index, QWidget* Widget)
 	{
-		Widget->setParent(nullptr);
 		if (index < 0)
 		{
 			index = m_Widgets.count();
@@ -143,6 +130,8 @@ public:
 			{
 				LayoutItem->widget()->setParent(nullptr);
 			}
+			delete LayoutItem;
+
 			m_CurrentWidget = nullptr;
 			m_CurrentIndex = -1;
 		}
@@ -182,11 +171,7 @@ public:
 			parent->setUpdatesEnabled(false);
 		}
 
-		auto LayoutItem = m_ParentLayout->takeAt(1);
-		if (LayoutItem)
-		{
-			LayoutItem->widget()->setParent(nullptr);
-		}
+		delete m_ParentLayout->takeAt(1);
 
 		m_ParentLayout->addWidget(next);
 		if (prev)
@@ -247,7 +232,7 @@ public:
 
 
 using DockAreaLayout = CDockAreaLayout;
-static constexpr DockWidgetAreas DefaultAllowedAreas = AllDockAreas;
+static const DockWidgetAreas DefaultAllowedAreas = AllDockAreas;
 
 
 /**

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -296,11 +296,11 @@ bool DockManagerPrivate::restoreStateFromXml(const QByteArray &state,  int versi
     {
 		// Delete remaining empty floating widgets
 		int FloatingWidgetIndex = DockContainerCount - 1;
-		int DeleteCount = FloatingWidgets.count() - FloatingWidgetIndex;
-		for (int i = 0; i < DeleteCount; ++i)
+		for (int i = FloatingWidgetIndex; i < FloatingWidgets.count(); ++i)
 		{
-			FloatingWidgets[FloatingWidgetIndex + i]->deleteLater();
-			_this->removeDockContainer(FloatingWidgets[FloatingWidgetIndex + i]->dockContainer());
+			auto* floatingWidget = FloatingWidgets[i];
+			_this->removeDockContainer(floatingWidget->dockContainer());
+			floatingWidget->deleteLater();
 		}
     }
 

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -542,6 +542,7 @@ void CDockWidget::setDockArea(CDockAreaWidget* DockArea)
 {
 	d->DockArea = DockArea;
 	d->ToggleViewAction->setChecked(DockArea != nullptr && !this->isClosed());
+	setParent(DockArea);
 }
 
 


### PR DESCRIPTION
* DockWidget always has DockAreaWidget as parent. It's not necessary to make it nullptr. This fixes many bugs related to restoring inactive tabbed DockWidgets.

* Fixed memory leaks related to QBoxLayout::takeAt().

* Fixed algorithm of deleting remaining floating widgets after restore.

Sorry for the pack. I don't have much time to make it in three different pull requests.

There were several commits recently that roughly delete DockWidgets if there is no parents, so they can be avoided, after this fix.