### PR TITLE
Prevent setFocus() recursion when application focus changes.

### DIFF
--- a/src/DockFocusController.cpp
+++ b/src/DockFocusController.cpp
@@ -240,7 +240,11 @@ void CDockFocusController::onApplicationFocusChanged(QWidget* focusedOld, QWidge
 		auto OtherDockWidgetTab = internal::findParent<CDockWidgetTab*>(focusedNow);
 		if (OtherDockWidgetTab && focusedOld)
 		{
-			focusedOld->setFocus();
+			auto OldFocusedDockWidget = internal::findParent<CDockWidget*>(focusedOld);
+			if (OldFocusedDockWidget)
+			{
+				focusedOld->setFocus();
+			}
 			return;
 		}
 	}


### PR DESCRIPTION
It is possible to create a `setFocus()` recursion under the following conditions:

CDockManager::FocusHighlighting = true
CDockManager::eConfigFlag::AllTabsHaveCloseButton = true
CDockManager::eConfigFlag::TabCloseButtonIsToolButton = true

with one dock widget set as the central widget and the other docks tabbed in the same area.

Reproduced with `CentralWidgetExample`:

![ezgif-3-e6831d590c48](https://user-images.githubusercontent.com/1648285/96406542-369e7e00-1212-11eb-9852-d5bde8c6e8f0.gif)
