### PR TITLE
Ensure that the stylesheet doesn't affect all QSplitter instances

### DIFF
--- a/src/stylesheets/default.css
+++ b/src/stylesheets/default.css
@@ -5,7 +5,7 @@ ads--CDockContainerWidget {
 	background: palette(dark);
 }
 
-ads--CDockContainerWidget QSplitter::handle {
+ads--CDockContainerWidget ads--CDockSplitter::handle {
 	background: palette(dark);
 }
 

--- a/src/stylesheets/default_linux.css
+++ b/src/stylesheets/default_linux.css
@@ -5,7 +5,7 @@ ads--CDockContainerWidget {
 	background: palette(dark);
 }
 
-ads--CDockContainerWidget QSplitter::handle {
+ads--CDockContainerWidget ads--CDockSplitter::handle {
 	background: palette(dark);
 }
 

--- a/src/stylesheets/focus_highlighting_linux.css
+++ b/src/stylesheets/focus_highlighting_linux.css
@@ -5,7 +5,7 @@ ads--CDockContainerWidget {
         background: palette(dark);
 }
 
-ads--CDockContainerWidget QSplitter::handle {
+ads--CDockContainerWidget ads--CDockSplitter::handle {
         background: palette(dark);
 }
 
@@ -192,3 +192,4 @@ ads--CFloatingDockContainer[isActiveWindow="true"] #floatingTitleMaximizeButton:
     background: rgba(255, 255, 255, 92);
 }
 */
+


### PR DESCRIPTION
The stylesheet should only change the style of ads::CDockSplitter
instances, but not all QSplitter instances. Otherwise all splitters
within any dock widget will also be affected and look different from
the default Qt style.