### PR TITLE
DockManager: add the ability to programmatically update splitter sizes

### DIFF
--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -55,6 +55,7 @@
 #include "DockingStateReader.h"
 #include "DockAreaTitleBar.h"
 #include "DockFocusController.h"
+#include "DockSplitter.h"
 
 #ifdef Q_OS_LINUX
 #include "linux/FloatingWidgetTitleBar.h"
@@ -1093,6 +1094,34 @@ CDockWidget* CDockManager::focusedDockWidget() const
 	}
 }
 
+//===========================================================================
+QList<int> CDockManager::splitterSizes(CDockAreaWidget *ContainedArea) const
+{
+    if (ContainedArea)
+    {
+        auto Splitter = internal::findParent<CDockSplitter*>(ContainedArea);
+        if (Splitter)
+        {
+            return Splitter->sizes();
+        }
+    }
+    return QList<int>();
+}
+
+//===========================================================================
+void CDockManager::setSplitterSizes(CDockAreaWidget *ContainedArea, const QList<int>& sizes)
+{
+    if (!ContainedArea)
+    {
+        return;
+    }
+
+    auto Splitter = internal::findParent<CDockSplitter*>(ContainedArea);
+    if (Splitter && Splitter->count() == sizes.count())
+    {
+        Splitter->setSizes(sizes);
+    }
+}
 
 } // namespace ads
 

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -487,6 +487,25 @@ public:
 	 */
 	CDockWidget* focusedDockWidget() const;
 
+    /**
+     * Returns the sizes of the splitter that contains the dock area.
+     *
+     * If there is no splitter that contains the area, an empty list will be
+     * returned.
+     */
+    QList<int> splitterSizes(CDockAreaWidget *ContainedArea) const;
+
+    /**
+     * Update the sizes of a splitter
+     * Programmatically updates the sizes of a given splitter by calling
+     * QSplitter::setSizes(). The splitter will be the splitter that
+     * contains the supplied dock area widget. If there is not splitter
+     * that contains the dock area, or the sizes supplied does not match
+     * the number of children of the splitter, this method will have no
+     * effect.
+     */
+    void setSplitterSizes(CDockAreaWidget *ContainedArea, const QList<int>& sizes);
+
 public slots:
 	/**
 	 * Opens the perspective with the given name.


### PR DESCRIPTION
Add the ability to programmatically update splitter sizes. The user must
specify the dock area that is contained in a splitter and a list of
sizes. The list of sizes will be passed to the splitter that immediately
contains the specified dock area. If the dock area is not part of a
splitter the method will have no effect.