### PR TITLE
Add utf-8 support for msvc to resolve building error in some windows systems.

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -23,7 +23,8 @@ windows {
 	}
 	# MSVC
 	*-msvc* {
-	}
+                QMAKE_CXXFLAGS += /utf-8
+        }
 }
 
 RESOURCES += ads.qrc


### PR DESCRIPTION
There are some non-ASCII characters "…" in ElidingLabel.cpp(default UTF-8 No Bom), and this will cause building error with msvc in some windows systems like mine(the default character-encoding is gbk).
`> chcp `
`Active code page: 936`
Adding utf-8 support for msvc can resolve this building error.