### PR TITLE
Add utf-8 support for msvc within cmake.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ set(ads_HEADERS
     IconProvider.h
     DockComponentsFactory.h
 )
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 if (UNIX AND NOT APPLE)
     set(ads_SRCS linux/FloatingWidgetTitleBar.cpp ${ads_SRCS})
     set(ads_HEADERS linux/FloatingWidgetTitleBar.h ${ads_HEADERS})


### PR DESCRIPTION
Continue #277 for cmake. 
I'm not familiar with cmake, so I just do this work according to [stack overflow](https://stackoverflow.com/questions/47690822/possible-to-force-cmake-msvc-to-use-utf-8-encoding-for-source-files-without-a-bo) and test passed.