### PR TITLE
Removes reliance on special Qt keywords.

### DIFF
--- a/src/DockContainerWidget.h
+++ b/src/DockContainerWidget.h
@@ -265,7 +265,7 @@ public:
 	 */
 	void closeOtherAreas(CDockAreaWidget* KeepOpenArea);
 
-signals:
+Q_SIGNALS:
 	/**
 	 * This signal is emitted if one or multiple dock areas has been added to
 	 * the internal list of dock areas.

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -506,7 +506,7 @@ public:
      */
     void setSplitterSizes(CDockAreaWidget *ContainedArea, const QList<int>& sizes);
 
-public slots:
+public Q_SLOTS:
 	/**
 	 * Opens the perspective with the given name.
 	 */
@@ -519,7 +519,7 @@ public slots:
 	 */
 	void setDockWidgetFocused(CDockWidget* DockWidget);
 
-signals:
+Q_SIGNALS:
 	/**
 	 * This signal is emitted if the list of perspectives changed
 	 */

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -58,7 +58,7 @@ private:
     DockWidgetPrivate* d; ///< private data (pimpl)
     friend struct DockWidgetPrivate;
 
-private slots:
+private Q_SLOTS:
     /**
      * Adjusts the toolbar icon sizes according to the floating state
      */
@@ -484,7 +484,7 @@ public: // reimplements QFrame -----------------------------------------------
      */
     virtual bool event(QEvent *e) override;
 
-public slots:
+public Q_SLOTS:
     /**
      * This property controls whether the dock widget is open or closed.
      * The toogleViewAction triggers this slot
@@ -545,7 +545,7 @@ public slots:
     void showNormal();
 
 
-signals:
+Q_SIGNALS:
     /**
      * This signal is emitted if the dock widget is opened or closed
      */

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -118,7 +118,7 @@ private:
 	friend class CDockAreaWidget;
     friend class CFloatingWidgetTitleBar;
 
-private slots:
+private Q_SLOTS:
 	void onDockAreasAddedOrRemoved();
 	void onDockAreaCurrentChanged(int Index);
 


### PR DESCRIPTION
This allows Qt Advanced Docking system to be compiled with the QT_NO_KEYWORDS definition. This can help avoid conflicts with other dependancies for a project.

For example, boost::signals.