### PR TITLE
Support multiple top-level ("main") windows

### DIFF
--- a/demo/StatusDialog.cpp
+++ b/demo/StatusDialog.cpp
@@ -42,7 +42,7 @@ StatusDialogPrivate::StatusDialogPrivate(CStatusDialog *_public) :
 
 //============================================================================
 CStatusDialog::CStatusDialog(ads::CDockManager* DockManager) :
-	QDialog(DockManager),
+	QDialog(),
 	d(new StatusDialogPrivate(this))
 {
 	d->ui.setupUi(this);

--- a/examples/sidebar/MainWindow.cpp
+++ b/examples/sidebar/MainWindow.cpp
@@ -17,7 +17,7 @@ MainWindow::MainWindow(QWidget *parent) :
 	QVBoxLayout* Layout = new QVBoxLayout(ui->dockContainer);
 	Layout->setContentsMargins(QMargins(0, 0, 0, 0));
 	m_DockManager = new ads::CDockManager(ui->dockContainer);
-	Layout->addWidget(m_DockManager);
+        Layout->addWidget(ui->dockContainer);
 
 	// Create example content label - this can be any application specific
 	// widget

--- a/src/DockContainerWidget.h
+++ b/src/DockContainerWidget.h
@@ -73,6 +73,7 @@ private:
 	friend class CDockWidget;
 	friend class CFloatingDragPreview;
 	friend struct FloatingDragPreviewPrivate;
+	using Super = QFrame;
 
 protected:
 	/**
@@ -215,6 +216,7 @@ public:
 	 * If all dock widgets in a dock area are closed, the dock area will be closed
 	 */
 	QList<CDockAreaWidget*> openedDockAreas() const;
+	void openedDockAreas(QList<CDockAreaWidget*>& result) const;
 
     /**
      * This function returns true if this dock area has only one single
@@ -264,6 +266,15 @@ public:
 	 * Call this function to close all dock areas except the KeepOpenArea
 	 */
 	void closeOtherAreas(CDockAreaWidget* KeepOpenArea);
+
+	/**
+	 * Show the floating widgets that has been created floating
+	 */
+	virtual void showEvent(QShowEvent *event); // override;
+
+#ifdef Q_OS_LINUX
+	bool eventFilter(QObject *obj, QEvent *e) override;
+#endif
 
 Q_SIGNALS:
 	/**

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -66,7 +66,10 @@ class CDockComponentsFactory;
  * DockManager->setStyleSheet("");
  * \endcode
  **/
-class ADS_EXPORT CDockManager : public CDockContainerWidget
+    class ADS_EXPORT CDockManager : public QObject
+#if 0
+    : public CDockContainerWidget
+#endif
 {
 	Q_OBJECT
 private:
@@ -138,11 +141,9 @@ protected:
 	/**
 	 * Show the floating widgets that has been created floating
 	 */
-	virtual void showEvent(QShowEvent *event) override;
+	virtual void showEvent(QShowEvent *event); // NOT override;
 
 public:
-	using Super = CDockContainerWidget;
-
 	enum eViewMenuInsertionOrder
 	{
 		MenuSortedByInsertion,
@@ -217,12 +218,15 @@ public:
 	 * Before you create any dock widgets, you should properly setup the
 	 * configuration flags via setConfigFlags().
 	 */
-	CDockManager(QWidget* parent = nullptr);
+	CDockManager(QWidget* parent);
+	CDockManager();
 
 	/**
 	 * Virtual Destructor
 	 */
 	virtual ~CDockManager() override;
+
+        CDockContainerWidget *addContainer(QWidget* window);
 
 	/**
 	 * This function returns the global configuration flags
@@ -304,6 +308,8 @@ public:
 	 */
 	void removeDockWidget(CDockWidget* Dockwidget);
 
+	QList<CDockAreaWidget*> openedDockAreas() const;
+
 	/**
 	 * This function returns a readable reference to the internal dock
 	 * widgets map so that it is possible to iterate over all dock widgets
@@ -320,12 +326,6 @@ public:
 	 * Returns the list of all floating widgets
 	 */
 	const QList<CFloatingDockContainer*> floatingWidgets() const;
-
-	/**
-	 * This function always return 0 because the main window is always behind
-	 * any floating widget
-	 */
-	unsigned int zOrderIndex() const override;
 
 	/**
 	 * Saves the current state of the dockmanger and all its dock widgets
@@ -474,10 +474,6 @@ public:
 
 		widget->setFocus(Qt::OtherFocusReason);
 	}
-
-#ifdef Q_OS_LINUX
-	bool eventFilter(QObject *obj, QEvent *e) override;
-#endif
 
 	/**
 	 * Returns the dock widget that has focus style in the ui or a nullptr if

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -567,7 +567,7 @@ void CDockWidget::saveState(QXmlStreamWriter& s) const
 void CDockWidget::flagAsUnassigned()
 {
 	d->Closed = true;
-	setParent(d->DockManager);
+	setParent(nullptr);
 	setVisible(false);
 	setDockArea(nullptr);
 	tabWidget()->setParent(this);

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -596,7 +596,7 @@ void FloatingDockContainerPrivate::handleEscapeKey()
 
 //============================================================================
 CFloatingDockContainer::CFloatingDockContainer(CDockManager *DockManager) :
-	tFloatingWidgetBase(DockManager),
+	tFloatingWidgetBase(),
 	d(new FloatingDockContainerPrivate(this))
 {
 	d->DockManager = DockManager;

--- a/src/FloatingDragPreview.cpp
+++ b/src/FloatingDragPreview.cpp
@@ -262,7 +262,7 @@ CFloatingDragPreview::CFloatingDragPreview(QWidget* Content, QWidget* parent) :
 
 //============================================================================
 CFloatingDragPreview::CFloatingDragPreview(CDockWidget* Content)
-	: CFloatingDragPreview((QWidget*)Content, Content->dockManager())
+    : CFloatingDragPreview((QWidget*)Content ,nullptr/*, Content->dockManager()*/)
 {
 	d->DockManager = Content->dockManager();
 	if (Content->dockAreaWidget()->openDockWidgetsCount() == 1)
@@ -275,7 +275,7 @@ CFloatingDragPreview::CFloatingDragPreview(CDockWidget* Content)
 
 //============================================================================
 CFloatingDragPreview::CFloatingDragPreview(CDockAreaWidget* Content)
-	: CFloatingDragPreview((QWidget*)Content, Content->dockManager())
+    : CFloatingDragPreview((QWidget*)Content, nullptr/*Content->dockManager()*/)
 {
 	d->DockManager = Content->dockManager();
 	d->ContentSourceArea = Content;


### PR DESCRIPTION
This attempts to separate out the data structures DockContainerWidget and DockManager so the latter does not inherit from the latter.  Instead a DockManager controls an arbitrary number of DockContainerWidgets, none of which are special (though there is a DefaultContainer, partly for compatibility).

The changes are mostly but not 100% compatible with existing applications.  I only needed to make 2 minor changes to the examples and demo. One regression I noticed and haven't figured out yet: the `sidebar` example is displaying wrong.

It might be possible to improve compatibility, though it could be at the cost of making the class hierarchy more confusing and fragile. The current pull-request trades off some breakage in favor of keep a clean relationship between the classes. 

This is work-in-progress; help/advice appreciated.

This is related to issue #290 .