### PR TITLE
Add Qt6 support on CMake

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(ads_demo VERSION ${VERSION_SHORT}) 
 
-find_package(Qt5 5.5 COMPONENTS Core Gui Widgets REQUIRED)
-if(WIN32)
-    find_package(Qt5 5.5 COMPONENTS AxContainer REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+if(WIN32 AND QT_VERSION_MAJOR LESS 6)
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS AxContainer REQUIRED)
 endif()
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(ads_demo_SRCS
@@ -16,9 +17,11 @@ set(ads_demo_SRCS
 )
 add_executable(AdvancedDockingSystemDemo WIN32 ${ads_demo_SRCS})
 target_include_directories(AdvancedDockingSystemDemo PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src")
-target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets)
-if(WIN32)
-    target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt5::AxContainer)
+target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::Core 
+                                                       Qt${QT_VERSION_MAJOR}::Gui 
+                                                       Qt${QT_VERSION_MAJOR}::Widgets)
+if(WIN32 AND QT_VERSION_MAJOR LESS 6)
+    target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::AxContainer)
 endif()
 target_link_libraries(AdvancedDockingSystemDemo PRIVATE qtadvanceddocking)
 set_target_properties(AdvancedDockingSystemDemo PROPERTIES 

--- a/examples/centralwidget/CMakeLists.txt
+++ b/examples/centralwidget/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ads_example_centralwidget VERSION ${VERSION_SHORT}) 
-find_package(Qt5 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(CentralWidgetExample WIN32 
     main.cpp
@@ -9,7 +10,9 @@ add_executable(CentralWidgetExample WIN32
 )
 target_include_directories(CentralWidgetExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(CentralWidgetExample PRIVATE qtadvanceddocking)
-target_link_libraries(CentralWidgetExample PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets)
+target_link_libraries(CentralWidgetExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
+                                                  Qt${QT_VERSION_MAJOR}::Gui 
+                                                  Qt${QT_VERSION_MAJOR}::Widgets)
 set_target_properties(CentralWidgetExample PROPERTIES 
     AUTOMOC ON
     AUTORCC ON

--- a/examples/deleteonclose/CMakeLists.txt
+++ b/examples/deleteonclose/CMakeLists.txt
@@ -1,13 +1,16 @@
 cmake_minimum_required(VERSION 3.5)
 project(ads_example_deleteonclose VERSION ${VERSION_SHORT}) 
-find_package(Qt5 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(DeleteOnCloseTest WIN32 
     main.cpp
 )
 target_include_directories(DeleteOnCloseTest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(DeleteOnCloseTest PRIVATE qtadvanceddocking)
-target_link_libraries(DeleteOnCloseTest PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets)
+target_link_libraries(DeleteOnCloseTest PUBLIC Qt${QT_VERSION_MAJOR}::Core 
+                                               Qt${QT_VERSION_MAJOR}::Gui 
+                                               Qt${QT_VERSION_MAJOR}::Widgets)
 set_target_properties(DeleteOnCloseTest PROPERTIES 
     AUTOMOC ON
     CXX_STANDARD 14

--- a/examples/dockindock/CMakeLists.txt
+++ b/examples/dockindock/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ads_example_simple VERSION ${VERSION_SHORT}) 
-find_package(Qt5 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(DockInDock WIN32 
     dockindock.cpp
@@ -12,7 +13,9 @@ add_executable(DockInDock WIN32
 )
 target_include_directories(SimpleExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(SimpleExample PRIVATE qtadvanceddocking)
-target_link_libraries(SimpleExample PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets)
+target_link_libraries(SimpleExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
+                                           Qt${QT_VERSION_MAJOR}::Gui 
+                                           Qt${QT_VERSION_MAJOR}::Widgets)
 set_target_properties(SimpleExample PROPERTIES 
     AUTOMOC ON
     AUTORCC ON

--- a/examples/emptydockarea/CMakeLists.txt
+++ b/examples/emptydockarea/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ads_example_centralwidget VERSION ${VERSION_SHORT}) 
-find_package(Qt5 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(EmptyDockAreaExample WIN32 
     main.cpp
@@ -9,7 +10,9 @@ add_executable(EmptyDockAreaExample WIN32
 )
 target_include_directories(EmptyDockAreaExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(EmptyDockAreaExample PRIVATE qtadvanceddocking)
-target_link_libraries(EmptyDockAreaExample PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets)
+target_link_libraries(EmptyDockAreaExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
+                                                  Qt${QT_VERSION_MAJOR}::Gui 
+                                                  Qt${QT_VERSION_MAJOR}::Widgets)
 set_target_properties(EmptyDockAreaExample PROPERTIES 
     AUTOMOC ON
     AUTORCC ON

--- a/examples/sidebar/CMakeLists.txt
+++ b/examples/sidebar/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ads_example_sidebar VERSION ${VERSION_SHORT}) 
-find_package(Qt5 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(SidebarExample WIN32 
     main.cpp
@@ -9,7 +10,9 @@ add_executable(SidebarExample WIN32
 )
 target_include_directories(SidebarExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(SidebarExample PRIVATE qtadvanceddocking)
-target_link_libraries(SidebarExample PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets)
+target_link_libraries(SidebarExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
+                                            Qt${QT_VERSION_MAJOR}::Gui 
+                                            Qt${QT_VERSION_MAJOR}::Widgets)
 set_target_properties(SidebarExample PROPERTIES 
     AUTOMOC ON
     AUTORCC ON

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ads_example_simple VERSION ${VERSION_SHORT}) 
-find_package(Qt5 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(SimpleExample WIN32 
     main.cpp
@@ -9,7 +10,9 @@ add_executable(SimpleExample WIN32
 )
 target_include_directories(SimpleExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(SimpleExample PRIVATE qtadvanceddocking)
-target_link_libraries(SimpleExample PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets)
+target_link_libraries(SimpleExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
+                                           Qt${QT_VERSION_MAJOR}::Gui 
+                                           Qt${QT_VERSION_MAJOR}::Widgets)
 set_target_properties(SimpleExample PROPERTIES 
     AUTOMOC ON
     AUTORCC ON

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(QtAdvancedDockingSystem LANGUAGES CXX VERSION ${VERSION_SHORT})
-find_package(Qt5 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 if (UNIX AND NOT APPLE)
-	find_package(Qt5 5.5 COMPONENTS X11Extras REQUIRED)
+	find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS X11Extras REQUIRED)
 endif()
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 if(BUILD_STATIC)
@@ -60,12 +61,14 @@ else()
     add_library(qtadvanceddocking SHARED ${ads_SRCS} ${ads_HEADERS})
     target_compile_definitions(qtadvanceddocking PRIVATE ADS_SHARED_EXPORT)
 endif()
-target_link_libraries(qtadvanceddocking PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets)
+target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core 
+                                               Qt${QT_VERSION_MAJOR}::Gui 
+                                               Qt${QT_VERSION_MAJOR}::Widgets)
 if(UNIX AND NOT APPLE)
-    target_link_libraries(qtadvanceddocking PUBLIC Qt5::X11Extras)
+    target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::X11Extras)
 	target_link_libraries(qtadvanceddocking PRIVATE xcb)
 endif()
-set_target_properties(qtadvanceddocking PROPERTIES 
+set_target_properties(qtadvanceddocking PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     CXX_STANDARD 14
@@ -84,13 +87,13 @@ write_basic_package_version_file(
     COMPATIBILITY SameMajorVersion
 )
 install(FILES ${ads_HEADERS}
-    DESTINATION include 
+    DESTINATION include
     COMPONENT headers
 )
-install(FILES 
+install(FILES
     "${CMAKE_SOURCE_DIR}/LICENSE"
     "${CMAKE_SOURCE_DIR}/gnu-lgpl-v2.1.md"
-    DESTINATION license 
+    DESTINATION license
     COMPONENT license
 )
 install(TARGETS qtadvanceddocking


### PR DESCRIPTION
Hey!

I noticed there was no Qt6 support on the CMake version of the build system. I added it!

Thanks again for your great work!