### PR TITLE
Fix objects deleted two times in CDockAreaTitleBar

### DIFF
--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -277,20 +277,6 @@ CDockAreaTitleBar::CDockAreaTitleBar(CDockAreaWidget* parent) :
 //============================================================================
 CDockAreaTitleBar::~CDockAreaTitleBar()
 {
-	if (!d->CloseButton.isNull())
-	{
-		delete d->CloseButton;
-	}
-
-	if (!d->TabsMenuButton.isNull())
-	{
-		delete d->TabsMenuButton;
-	}
-
-	if (!d->UndockButton.isNull())
-	{
-		delete d->UndockButton;
-	}
 	delete d;
 }
 


### PR DESCRIPTION
Manually delete the QPointer content cause an error when later the QPointer try to deref and automatically delete the object.

I checked the code and I dont' see a reason because these objects need to be manually deleted (i hope i'm not wrong). So remove that lines should be fine and solve the problem.

This is the stack trace that I got in my project when I try to close the application
```
>	ntdll.dll!RtlReportCriticalFailure()	Unknown
 	ntdll.dll!RtlpHeapHandleError()	Unknown
 	ntdll.dll!RtlpHpHeapHandleError()	Unknown
 	ntdll.dll!RtlpLogHeapFailure()	Unknown
 	ntdll.dll!RtlpFreeHeapInternal()	Unknown
 	ntdll.dll!RtlFreeHeap()	Unknown
 	ucrtbase.dll!_free_base()	Unknown
 	ChronicleEditor.exe!QtSharedPointer::ExternalRefCountData::operator delete(void * ptr) Line 156	C++
 	[External Code]	
 	ChronicleEditor.exe!QWeakPointer<QObject>::~QWeakPointer<QObject>() Line 572	C++
 	[External Code]	
 	ChronicleEditor.exe!ads::CDockAreaTitleBar::~CDockAreaTitleBar() Line 298	C++
```

My environment:
- Windows 10 x64
- QT 6.0.3 MSVC64
