### PR TITLE
Update icon label tooltip when the tab tooltip changes

### DIFF
--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -677,6 +677,9 @@ bool CDockWidgetTab::event(QEvent *e)
 	{
 		const auto text = toolTip();
 		d->TitleLabel->setToolTip(text);
+		if (d->IconLabel) {
+			d->IconLabel->setToolTip(text);
+		}
 	}
 #endif
 	return Super::event(e);


### PR DESCRIPTION
When changing the tooltip of the tab the icon label tooltip was not updated, but the tooltip of the text was.
This is a super minor change that fixes it.