### PR TITLE
Remove deprecation warning while building with Qt5.15

### DIFF
--- a/src/DockOverlay.cpp
+++ b/src/DockOverlay.cpp
@@ -806,7 +806,7 @@ void CDockOverlayCross::setIconColors(const QString& Colors)
 		{"Arrow", CDockOverlayCross::ArrowColor},
 		{"Shadow", CDockOverlayCross::ShadowColor}};
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
     auto SkipEmptyParts = QString::SkipEmptyParts;
 #else
     auto SkipEmptyParts = Qt::SkipEmptyParts;


### PR DESCRIPTION
Another tiny change.
`QString::SkipEmptyParts` was marked for deprecation in Qt5.15. This removes the warning.
Since `Qt::SkipEmptyParts` was added in 5.14.0 I just check for that.