### PR TITLE
Fix issue #351

### DIFF
--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -1565,8 +1565,9 @@ void CDockContainerWidget::dropFloatingWidget(CFloatingDockContainer* FloatingWi
 	}
 
 	if (Dropped)
-	{
-		FloatingWidget->deleteLater();
+	{ 
+		// Fix https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/351
+		FloatingWidget->hideAndDeleteLater();
 
 		// If we dropped a floating widget with only one single dock widget, then we
 		// drop a top level widget that changes from floating to docked now

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -258,6 +258,11 @@ public:
      */
     QList<CDockWidget*> dockWidgets() const;
 
+	/**
+	 * This function hides the floating bar instantely and delete it later.
+	 */
+	void hideAndDeleteLater();
+
 #ifdef Q_OS_LINUX
     /**
 	 * This is a function that responds to FloatingWidgetTitleBar::maximizeRequest()


### PR DESCRIPTION
See https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/351

Hide the floating dock container when the widget has been redocked without hiding the contained widget