### PR TITLE
Fix MSVC compiler warning C4275

### DIFF
--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -65,7 +65,7 @@ class CDockingStateReader;
  * This interface is used for opaque and non-opaque undocking. If opaque
  * undocking is used, the a real CFloatingDockContainer widget will be created
  */
-class IFloatingWidget
+class ADS_EXPORT IFloatingWidget
 {
 public:
     virtual ~IFloatingWidget() = default;


### PR DESCRIPTION
The CFloatingDockContainer is exported, but inherits from a base
class that is not exported. This triggers a compiler warning under
MSVC toolchain. This patch fixes the issue by exporting the
IFloatingWidget class.