### PR TITLE
Added CDockWidget feature to recreate widgets from a factory

### DIFF
--- a/examples/deleteonclose/main.cpp
+++ b/examples/deleteonclose/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
         now->widget()->setFocus();
     });
 
-    QAction *action = new QAction("New Delete On Close", &w);
+    QAction *action = new QAction("New Delete Dock Widget On Close", &w);
     w.menuBar()->addAction(action);
 
     int i = 0;
@@ -53,7 +53,26 @@ int main(int argc, char *argv[])
         auto area = dockManager->addDockWidgetTab(ads::CenterDockWidgetArea, dw);
         qDebug() << "doc dock widget created!" << dw << area;
     });
-
+	
+	auto dw = new ads::CDockWidget(QStringLiteral("test doc %1").arg(i++), &w);
+	auto editor = new QTextEdit(QStringLiteral("recreated lorem ipsum......"), dw);
+	dw->setWidget(editor);
+	dw->setFeature(ads::CDockWidget::RecreateContentsWidgetOnCloseAndOpen, true);
+	dw->setWidgetFactory([](QWidget* dw){
+		static int timesRecreated = 0;
+		return new QTextEdit(QStringLiteral("recreated lorem ipsum... times %1").arg(++timesRecreated), dw);
+	});
+	auto area = dockManager->addDockWidgetTab(ads::CenterDockWidgetArea, dw);
+	qDebug() << "RecreateContentsWidgetOnCloseAndOpen dock widget created!" << dw << area;
+	
+	action = new QAction("Toggle Recreate Contents Widget On Close and Open", &w);
+    w.menuBar()->addAction(action);
+	
+	QObject::connect(action, &QAction::triggered, [dw]() {
+		dw->toggleView(dw->isClosed());
+		qDebug() << QString("dock widget %1! contents widget %2!").arg(dw->isClosed() ? "closed" : "open", dw->widget() ? "created" : "deleted");
+    });
+	
     action = new QAction("New", &w);
     w.menuBar()->addAction(action);
     QObject::connect(action, &QAction::triggered, [&]() {

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -147,18 +147,19 @@ public:
 
     enum DockWidgetFeature
     {
-        DockWidgetClosable = 0x01,///< dock widget has a close button
-        DockWidgetMovable = 0x02,///< dock widget is movable and can be moved to a new position in the current dock container
-        DockWidgetFloatable = 0x04,///< dock widget can be dragged into a floating window
-        DockWidgetDeleteOnClose = 0x08, ///< deletes the dock widget when it is closed
-        CustomCloseHandling = 0x10, ///< clicking the close button will not close the dock widget but emits the closeRequested() signal instead
-        DockWidgetFocusable = 0x20, ///< if this is enabled, a dock widget can get focus highlighting
-        DockWidgetForceCloseWithArea = 0x40, ///< dock widget will be closed when the dock area hosting it is closed
-        NoTab = 0x80, ///< dock widget tab will never be shown if this flag is set
+        DockWidgetClosable = 0x001,///< dock widget has a close button
+        DockWidgetMovable = 0x002,///< dock widget is movable and can be moved to a new position in the current dock container
+        DockWidgetFloatable = 0x004,///< dock widget can be dragged into a floating window
+        DockWidgetDeleteOnClose = 0x008, ///< deletes the dock widget when it is closed
+        CustomCloseHandling = 0x010, ///< clicking the close button will not close the dock widget but emits the closeRequested() signal instead
+        DockWidgetFocusable = 0x020, ///< if this is enabled, a dock widget can get focus highlighting
+        DockWidgetForceCloseWithArea = 0x040, ///< dock widget will be closed when the dock area hosting it is closed
+        NoTab = 0x080, ///< dock widget tab will never be shown if this flag is set
+        RecreateContentsWidgetOnCloseAndOpen = 0x100, ///< deletes only the contained widget on close, keeping the dock widget intact and in place. Attempts to rebuild the contents widget on show if there is a widget factory set.
         DefaultDockWidgetFeatures = DockWidgetClosable | DockWidgetMovable | DockWidgetFloatable | DockWidgetFocusable,
         AllDockWidgetFeatures = DefaultDockWidgetFeatures | DockWidgetDeleteOnClose | CustomCloseHandling,
         DockWidgetAlwaysCloseAndDelete = DockWidgetForceCloseWithArea | DockWidgetDeleteOnClose,
-        NoDockWidgetFeatures = 0x00
+        NoDockWidgetFeatures = 0x000
     };
     Q_DECLARE_FLAGS(DockWidgetFeatures, DockWidgetFeature)
 
@@ -269,7 +270,18 @@ public:
      * provide the InsertMode ForceNoScrollArea
      */
     void setWidget(QWidget* widget, eInsertMode InsertMode = AutoScrollArea);
-
+	
+	/**
+	 * Only used when the flag RecreateContentsWidgetOnCloseAndOpen is set.
+	 * Using the flag and setting a widget factory allows to free the resources of
+	 * the widget of your application while retaining the position the next time you want to
+	 * show your widget, unlike the flag DockWidgetDeleteOnClose which deletes the dock widget itself.
+	 * Since we keep the dock widget, all regular features of ADS should work as normal, including
+	 * saving and restoring the state of the docking system and using perspectives.
+	 */
+	using FactoryFunc = std::function<QWidget*(QWidget*)>;
+	void setWidgetFactory(FactoryFunc createWidget, eInsertMode InsertMode = AutoScrollArea);
+	
     /**
      * Remove the widget from the dock and give ownership back to the caller
      */


### PR DESCRIPTION
Sorry for the wall of text, since we talked about this before this is my attempt at making you understand the problem and why this feature is needed.

As we know, by default all widgets are supposed to be created at the start of the application and using the save states (or perspectives) the widgets are shown or hidden (and kept alive). I would say this is fine for most applications, but in more complex applications, it raises several problems:
- Several of the shown widgets could have the same underlying components and connect to the same signals and systems. When debugging a particular slot that is listened to by several instances of the same widget, it becomes quite painful to find the right instance. Being able to close of delete other instances is a very fast way to improve this process.
- It is common for users to open a complex widget and notice a slow down. They might be in underpowered machines that are not capable of running a lot of widgets at the same time without penalty. The expected result is that they attempt to close widgets to see if the application can run faster. This was the case in our application before ADS was implemented. If the widgets would delete on close it would improve the situation drastically for them.

The `DeleteOnClose` flag allows this deletion to happen, but with limitations. Using the flag, dock widgets are fully deleted and will lose all context about the place where they were spawned. This behavior is fine for widgets that always have a specific spawning area and that might be infinite in number; it is mainly intended for document widgets and it works wonderfully for that. For regular widgets though, this is not great at all, users expect the widget to reappear in the same place where they closed it.

The new flag is intended to use the default capabilities of ADS and allow for application widgets to be deleted and recreated internally by the dock widgets themselves. This allows to keep the context of the dock widgets as usual, and save them and everything, while at the same time be able to delete and release the resources of these complex widgets. This improves memory usage of the application, allows the user to optimize it a bit and allows for a better debugging experience. Additionally, in my case it allows plugins to retain their position when they are installed or uninstalled, and appear in the same place with minimal impact.

This is a gif of it in action, I added a menu action in the `deleteonclose` without modifying the other two actions to see how it behaves in comparison.
![w3wFtJGNCO](https://user-images.githubusercontent.com/1664301/136928630-92cbb517-1a3a-4bb5-9d9c-4092f99f31cf.gif)