### PR TITLE
Fix crash when adding closed dock widgets to the manager

### DIFF
--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -597,7 +597,8 @@ void CDockWidget::toggleViewInternal(bool Open)
 	CDockWidget* TopLevelDockWidgetAfter = DockContainer
 		? DockContainer->topLevelDockWidget() : nullptr;
 	CDockWidget::emitTopLevelEventForWidget(TopLevelDockWidgetAfter, true);
-	CFloatingDockContainer* FloatingContainer = DockContainer->floatingWidget();
+	CFloatingDockContainer* FloatingContainer = DockContainer
+		? DockContainer->floatingWidget() : nullptr;
 	if (FloatingContainer)
 	{
 		FloatingContainer->updateWindowTitle();


### PR DESCRIPTION
I got a crash when adding a closed dock widget to the manager here. It was already checking if the dock container exists all the way up, it was only missing this one spot.