### PR TITLE
Prevent middle-click from closing unclosable tabs

### DIFF
--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -407,7 +407,7 @@ void CDockWidgetTab::mouseReleaseEvent(QMouseEvent* ev)
 	} 
 	else if (ev->button() == Qt::MiddleButton)
 	{
-		if (CDockManager::testConfigFlag(CDockManager::MiddleMouseButtonClosesTab))
+		if (CDockManager::testConfigFlag(CDockManager::MiddleMouseButtonClosesTab) && dockWidget->features().testFlag(CDockWidget::DockWidgetClosable))
 		{
 			// Only attempt to close if the mouse is still
 			// on top of the widget, to allow the user to cancel.


### PR DESCRIPTION
This fixes a bug where, if `CDockManager::MiddleMouseButtonClosesTab` is enabled, you could close a dock widget by middle-clicking its tab even if its `CDockWidget::DockWidgetClosable` flag is set to `false`.