### PR TITLE
add QFlag operators

### DIFF
--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -367,7 +367,8 @@ Q_SIGNALS:
 	 */
 	void viewToggled(bool Open);
 }; // class DockAreaWidget
-}
- // namespace ads
+} // namespace ads
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(ads::CDockAreaWidget::DockAreaFlags)
 //-----------------------------------------------------------------------------
 #endif // DockAreaWidgetH

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -617,5 +617,7 @@ Q_SIGNALS:
     void focusedDockWidgetChanged(ads::CDockWidget* old, ads::CDockWidget* now);
 }; // class DockManager
 } // namespace ads
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(ads::CDockManager::ConfigFlags)
 //-----------------------------------------------------------------------------
 #endif // DockManagerH

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -600,7 +600,8 @@ Q_SIGNALS:
      */
     void featuresChanged(ads::CDockWidget::DockWidgetFeatures features);
 }; // class DockWidget
-}
- // namespace ads
+} // namespace ads
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(ads::CDockWidget::DockWidgetFeatures)
 //-----------------------------------------------------------------------------
 #endif // DockWidgetH

--- a/src/ads_globals.h
+++ b/src/ads_globals.h
@@ -308,5 +308,6 @@ void repolishStyle(QWidget* w, eRepolishChildOptions Options = RepolishIgnoreChi
 } // namespace internal
 } // namespace ads
 
+Q_DECLARE_OPERATORS_FOR_FLAGS(ads::DockWidgetAreas)
 //---------------------------------------------------------------------------
 #endif // ads_globalsH


### PR DESCRIPTION
The following doesn't currently work, but would be consistent with the usual flag usage.
```cpp
using namespace ads;
CDockWidget dock("foobar");
dock.setFeatures(CDockWidget::DockWidgetClosable | CDockWidget::DockWidgetMovable);
```

[`Q_DECLARE_OPERATORS_FOR_FLAGS(Flags)`](https://doc.qt.io/qt-5/qflags.html#Q_DECLARE_OPERATORS_FOR_FLAGS) declares the necessary operators.