### PR TITLE
Don't show empty floating containers on startup

### DIFF
--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -762,7 +762,10 @@ void CDockManager::showEvent(QShowEvent *event)
 
 	for (auto FloatingWidget : d->UninitializedFloatingWidgets)
 	{
-		FloatingWidget->show();
+		if (!FloatingWidget->dockContainer()->openedDockAreas().isEmpty())
+		{
+			FloatingWidget->show();
+		}
 	}
 	d->UninitializedFloatingWidgets.clear();
 }


### PR DESCRIPTION
If you add a floating dock widget to the dock manager, and then close it before the dock manager is shown, showing the dock manager will currently cause the empty floating dock container to be shown.

This fixes this behaviour so that the empty floating container is not shown in this circumstance, making it consistent with the behaviour if the above is performed while the dock manager is visible.

(I've confirmed that this builds without any other changes, so hopefully I'll avoid a repeat of my last PR… 😛)