### PR TITLE
Fix potential crash when restoring container state

### DIFF
--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -1680,7 +1680,10 @@ bool CDockContainerWidget::restoreState(CDockingStateReader& s, bool Testing)
 		if (!Testing)
 		{
 			CFloatingDockContainer* FloatingWidget = floatingWidget();
-			FloatingWidget->restoreGeometry(Geometry);
+			if (FloatingWidget)
+			{
+				FloatingWidget->restoreGeometry(Geometry);
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes a crash which could occur when restoring the state of a floating container to a non-floating container.

This was because `ads::CDockContainerWidget::RestoreState()` will unconditionally assume this is floating if the XML has the `Floating` boolean set, and will dereference `floatingWidget()`. If this isn't floating, `floatingWidget()` will return `nullptr`, leading to a crash when it's subsequently used.

Fixes #379.