### PR TITLE
Removed ContentMargin in DockContainerWidget

### DIFF
--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -1286,7 +1286,7 @@ CDockContainerWidget::CDockContainerWidget(CDockManager* DockManager, QWidget *p
 	d->isFloating = floatingWidget() != nullptr;
 
 	d->Layout = new QGridLayout();
-	d->Layout->setContentsMargins(0, 1, 0, 1);
+	d->Layout->setContentsMargins(0, 0, 0, 0);
 	d->Layout->setSpacing(0);
 	setLayout(d->Layout);
 

--- a/src/stylesheets/default.css
+++ b/src/stylesheets/default.css
@@ -4,6 +4,9 @@
 ads--CDockContainerWidget {
 	background: palette(dark);
 }
+ads--CDockContainerWidget > QSplitter{
+        padding: 1 0 1 0;
+}
 
 ads--CDockContainerWidget ads--CDockSplitter::handle {
 	background: palette(dark);

--- a/src/stylesheets/default_linux.css
+++ b/src/stylesheets/default_linux.css
@@ -4,6 +4,9 @@
 ads--CDockContainerWidget {
 	background: palette(dark);
 }
+ads--CDockContainerWidget > QSplitter{
+        padding: 1 0 1 0;
+}
 
 ads--CDockContainerWidget ads--CDockSplitter::handle {
 	background: palette(dark);

--- a/src/stylesheets/focus_highlighting.css
+++ b/src/stylesheets/focus_highlighting.css
@@ -4,6 +4,9 @@
 ads--CDockContainerWidget {
 	background: palette(dark);
 }
+ads--CDockContainerWidget > QSplitter{
+        padding: 1 0 1 0;
+}
 
 ads--CDockAreaWidget {
 	background: palette(window);

--- a/src/stylesheets/focus_highlighting_linux.css
+++ b/src/stylesheets/focus_highlighting_linux.css
@@ -4,6 +4,10 @@
 ads--CDockContainerWidget {
         background: palette(dark);
 }
+ads--CDockContainerWidget > QSplitter{
+        padding: 1 0 1 0;
+}
+
 
 ads--CDockContainerWidget ads--CDockSplitter::handle {
         background: palette(dark);


### PR DESCRIPTION
Currently the DockContainerWidget sets a content margin of 0,1,0,1 (top and bottom) and since it is not possible in QT to influence layouts via stylesheets this leads to issues with custom stylesheets.
See: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/blob/master/src/DockContainerWidget.cpp#L1289 

This PR removes the content margin set in code and replaces it with padding to the child QSplitter instead.
This should behave the same as before (when using the default stylesheets) but allows to get rid of it if required.