### PR TITLE
Add method to add dock widget to dock container

### DIFF
--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -823,6 +823,16 @@ CDockAreaWidget* CDockManager::addDockWidget(DockWidgetArea area,
 	return AreaOfAddedDockWidget;
 }
 
+//============================================================================
+CDockAreaWidget* CDockManager::addDockWidgetToContainer(DockWidgetArea area,
+	CDockWidget* Dockwidget, CDockContainerWidget* DockContainerWidget)
+{
+	d->DockWidgetsMap.insert(Dockwidget->objectName(), Dockwidget);
+	auto AreaOfAddedDockWidget = DockContainerWidget->addDockWidget(area, Dockwidget);
+	Q_EMIT dockWidgetAdded(Dockwidget);
+	return AreaOfAddedDockWidget;
+}
+
 
 //============================================================================
 CDockAreaWidget* CDockManager::addDockWidgetTab(DockWidgetArea area,

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -284,6 +284,15 @@ public:
 		CDockAreaWidget* DockAreaWidget = nullptr);
 
 	/**
+	 * Adds dockwidget into the given container.
+	 * This allows you to place the dock widget into a container, even if that
+	 * container does not yet contain a DockAreaWidget.
+	 * \return Returns the dock area widget that contains the new DockWidget
+	 */
+	CDockAreaWidget* addDockWidgetToContainer(DockWidgetArea area, CDockWidget* Dockwidget,
+		CDockContainerWidget* DockContainerWidget);
+
+	/**
 	 * This function will add the given Dockwidget to the given dock area as
 	 * a new tab.
 	 * If no dock area widget exists for the given area identifier, a new


### PR DESCRIPTION
Fixes #394, by implementing a method that I suggested there.

This adds a `addDockWidgetToContainer()` method to `CDockManager`, which allows a dock widget to be registered with the dock manager, and added to a specific container, even if that container doesn't currently have any `DockAreaWidget`s.

This is pretty much just a clone of `addDockWidget()`, but with the ability to specify a container widget instead of a dock area.