### PR TITLE
fix centos stuck issue

### DIFF
--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -1239,12 +1239,12 @@ void CFloatingDockContainer::resizeEvent(QResizeEvent *event)
 	Super::resizeEvent(event);
 }
 
-
+static bool s_mousePressed = false;
 //============================================================================
 void CFloatingDockContainer::moveEvent(QMoveEvent *event)
 {
 	Super::moveEvent(event);
-	if (!d->IsResizing && event->spontaneous())
+	if (!d->IsResizing && event->spontaneous() && s_mousePressed)
 	{
 		d->DraggingState = DraggingFloatingWidget;
 		d->updateDropOverlays(QCursor::pos());
@@ -1252,6 +1252,23 @@ void CFloatingDockContainer::moveEvent(QMoveEvent *event)
 	d->IsResizing = false;
 }
 
+//============================================================================
+bool CFloatingDockContainer::event(QEvent *e)
+{
+	bool result = Super::event(e);
+	switch (e->type())
+	{
+	case QEvent::WindowActivate:
+		s_mousePressed = false;
+		break;
+	case QEvent::WindowDeactivate:
+		s_mousePressed = true;
+		break;
+	default:
+		break;
+	}
+	return result;
+}
 
 //============================================================================
 bool CFloatingDockContainer::hasNativeTitleBar()

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -188,6 +188,7 @@ protected: // reimplements QWidget
 #ifdef Q_OS_LINUX
 	virtual void moveEvent(QMoveEvent *event) override;
 	virtual void resizeEvent(QResizeEvent *event) override;
+	virtual bool event(QEvent *e) override;
 #endif
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
fix(issue-350): on RedHat/CentOS, sometimes there will be one more move event after user release their mouse which will cause the floating overlay can not be hide. Here we use the WindowActivate and WindowDeactivate event to check whether user release their mouse.