### PR TITLE
CMake bugfixes [target alias, license install]

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,9 @@ else()
     add_library(qtadvanceddocking SHARED ${ads_SRCS} ${ads_HEADERS})
     target_compile_definitions(qtadvanceddocking PRIVATE ADS_SHARED_EXPORT)
 endif()
+
+add_library(ads::qtadvanceddocking ALIAS qtadvanceddocking)
+
 target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,9 +90,9 @@ install(FILES ${ads_HEADERS}
     COMPONENT headers
 )
 install(FILES
-    "${CMAKE_SOURCE_DIR}/LICENSE"
-    "${CMAKE_SOURCE_DIR}/gnu-lgpl-v2.1.md"
-    DESTINATION license
+    "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../gnu-lgpl-v2.1.md"
+    DESTINATION license/ads
     COMPONENT license
 )
 install(TARGETS qtadvanceddocking


### PR DESCRIPTION
# CMake target alias

- When linking the library as **imported target** (e.g. using vcpkg) it will link it against the name `ads::qtadvanceddocking`, because we exported it in `ads::` namespace. 
- But when linking the library **as subdirectory** (e.g. using CMake FetchContent), we would link it with `qtadvanceddocking`, without namespace.

It's a common practice to add CMake ALIAS target to fix this.
Adding alias fixes this, so you always link the target with common `ads::qtadvanceddocking`, regardless the target type.

# CMake license install

1. Changed path to license source files using `CURRENT_SOURCE_DIR`. This is needed when adding the library to the project as subdirectory.
2. Changed license destination path to `license/ads`, to prevent different libraries licence overwrite.