### PR TITLE
Set required C++ standard depending on Qt version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,8 +70,6 @@ target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core
 set_target_properties(qtadvanceddocking PROPERTIES
     AUTOMOC ON
     AUTORCC ON
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "qtadvanceddocking"
@@ -79,6 +77,16 @@ set_target_properties(qtadvanceddocking PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
 )
+if(QT_VERSION_MAJOR STREQUAL "5")
+    set_target_properties(qtadvanceddocking PROPERTIES
+        CXX_STANDARD 14
+        CXX_STANDARD_REQUIRED ON)
+elseif(QT_VERSION_MAJOR STREQUAL "6")
+    set_target_properties(qtadvanceddocking PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON)
+endif()
+
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     "qtadvanceddockingConfigVersion.cmake"


### PR DESCRIPTION
Qt6 requires C++17 for building and for being used as part of a project. ADS however only requires C++14 so far. Now when building using Conon for example the packages are built independently and ADS is built using the C++-14 flag which in turn causes the included Qt6 headers to fail the compile process. This patch bumps the required C++ standard to C++17 for builds targeting Qt6 only.

For example this is  part of the output when building with Conan against Qt6 without the provided patch (sorry for the color-escapes trouble):

> -- Generating done
> -- Build files have been written to: /home/user/.conan/data/qt-advanced-docking-system/3.8.2/_/_/build/05d8c98cf4a7dcaed67ebc1c04d0a853dadeab36
> [  4%] Automatic MOC for target qtadvanceddocking
> [  4%] Built target qtadvanceddocking_autogen
> [  8%] Automatic RCC for ads.qrc
> [ 17%] Building CXX object source_subfolder/src/CMakeFiles/qtadvanceddocking.dir/qtadvanceddocking_autogen/mocs_compilation.cpp.o
> [ 17%] Building CXX object source_subfolder/src/CMakeFiles/qtadvanceddocking.dir/linux/FloatingWidgetTitleBar.cpp.o
> [ 21%] Building CXX object source_subfolder/src/CMakeFiles/qtadvanceddocking.dir/ads_globals.cpp.o
> [ 26%] Building CXX object source_subfolder/src/CMakeFiles/qtadvanceddocking.dir/DockAreaTabBar.cpp.o
> [ 30%] Building CXX object source_subfolder/src/CMakeFiles/qtadvanceddocking.dir/DockAreaTitleBar.cpp.o
> [ 34%] Building CXX object source_subfolder/src/CMakeFiles/qtadvanceddocking.dir/DockAreaWidget.cpp.o
> [ 39%] Building CXX object source_subfolder/src/CMakeFiles/qtadvanceddocking.dir/DockContainerWidget.cpp.o
> [ 43%] Building CXX object source_subfolder/src/CMakeFiles/qtadvanceddocking.dir/DockManager.cpp.o
> In file included from [01m[K/home/user/.conan/data/qt/6.3.1/_/_/package/84c4076b41cd073eba3d6bcd7be423961c704ebe/include/QtCore/qatomic.h:41[m[K,
>                  from [01m[K/home/user/.conan/data/qt/6.3.1/_/_/package/84c4076b41cd073eba3d6bcd7be423961c704ebe/include/QtCore/qvariant.h:43[m[K,
>                  from [01m[K/home/user/.conan/data/qt/6.3.1/_/_/package/84c4076b41cd073eba3d6bcd7be423961c704ebe/include/QtCore/QVariant:1[m[K,
>                  from [01m[K/home/user/.conan/data/qt-advanced-docking-system/3.8.2/_/_/build/05d8c98cf4a7dcaed67ebc1c04d0a853dadeab36/source_subfolder/src/ads_globals.cpp:31[m[K:
> [01m[K/home/user/.conan/data/qt/6.3.1/_/_/package/84c4076b41cd073eba3d6bcd7be423961c704ebe/include/QtCore/qglobal.h:143:6:[m[K [01;31m[Kerror: [m[K#error "Qt requires a C++17 compiler"
>   143 | #    [01;31m[Kerror[m[K "Qt requires a C++17 compiler"
>       |      [01;31m[K^~~~~[m[K
> In file included from [01m[K/home/user/.conan/data/qt/6.3.1/_/_/package/84c4076b41cd073eba3d6bcd7be423961c704ebe/include/QtGui/qtguiglobal.h:43[m[K,
>                  from [01m[K/home/user/.conan/data/qt/6.3.1/_/_/package/84c4076b41cd073eba3d6bcd7be423961c704ebe/include/QtWidgets/qtwidgetsglobal.h:43[m[K,
>                  from [01m[K/home/user/.conan/data/qt/6.3.1/_/_/package/84c4076b41cd073eba3d6bcd7be423961c704ebe/include/QtWidgets/qframe.h:43[m[K,
>                  from [01m[K/home/user/.conan/data/qt/6.3.1/_/_/package/84c4076b41cd073eba3d6bcd7be423961c704ebe/include/QtWidgets/QFrame:1[m[K,
>                  from [01m[K/home/user/.conan/data/qt-advanced-docking-system/3.8.2/_/_/build/05d8c98cf4a7dcaed67ebc1c04d0a853dadeab36/source_subfolder/src/DockAreaTitleBar.h:33[m[K,
>                  from [01m[K/home/user/.conan/data/qt-advanced-docking-system/3.8.2/_/_/build/05d8c98cf4a7dcaed67ebc1c04d0a853dadeab36/source_subfolder/src/DockAreaTitleBar.cpp:30[m[K:
> [01m[K/home/user/.conan/data/qt/6.3.1/_/_/package/84c4076b41cd073eba3d6bcd7be423961c704ebe/include/QtCore/qglobal.h:143:6:[m[K [01;31m[Kerror: [m[K#error "Qt requires a C++17 compiler"
> [...]
