### PR TITLE
Add link to xcb library on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,9 @@ add_library(ads::qtadvanceddocking ALIAS qtadvanceddocking)
 target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)
+if (UNIX AND NOT APPLE)
+  target_link_libraries(qtadvanceddocking PUBLIC xcb)
+endif()
 set_target_properties(qtadvanceddocking PROPERTIES
     AUTOMOC ON
     AUTORCC ON


### PR DESCRIPTION
As suggested here: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/270#issuecomment-717178889

I was unable to build using the LLD linker before adding this, getting the same "undefined reference to xcb_*" errors.