### PR TITLE
Remove version check for qt 5.x to fix conan qt6 compatibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(QtAdvancedDockingSystem LANGUAGES CXX VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Widgets REQUIRED)
 if (UNIX AND NOT APPLE)
     include_directories(${Qt${QT_VERSION_MAJOR}Gui_PRIVATE_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
Qt6 compatibility is broken in some cases when building with conan. This is due to the find_package version check against 5.5 rejecting the Qt6 version (e.g. 6.3.1).

For example this is a possible output which we are currently facing on the Conan Center CI:

> CMake Error at src/CMakeLists.txt:4 (find_package):
>   Could not find a configuration file for package "Qt6" that is compatible
>   with requested version "5.5".
> 
>   The following configuration files were considered but not accepted:
> 
>     /home/conan/w/prod/BuildSingleReference/.conan/data/qt-advanced-docking-system/3.8.2/_/_/build/fe39716ce00f0da6fc16495bd074b5a38407e58e/Qt6Config.cmake, version: 6.3.1

One option is to remove the version check altogether as proposed with this patch. The version check allowed versions starting from v5.5. The support for earlier versions than that (<=5.4) ended 5 years ago (disregarding extended support) so I think it is unlikely to still find someone trying to build against Qt 5.4 while earlier and still being able to fulfill the C++14 requirement. In my opinion the cost of increasing complexity by reworking the version check to act differently for qt 5 and qt6 outweighs the advantage of it which is why I removed the check entirely.

However if it is preferred to have that version check I can provide a patch that does something along the lines of this:
```cmake
find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
if(QT_VERSION_MAJOR STREQUAL "5")
    set(QT_MINIMUM_VERSION_REQUIRED "5.5")
else()
    set(QT_MINIMUM_VERSION_REQUIRED "6.0")
endif()
find_package(Qt${QT_VERSION_MAJOR} ${QT_MINIMUM_VERSION_REQUIRED} COMPONENTS Core Gui Widgets REQUIRED)
```

A third solution (arguably not my favorite one) would be to reject the patch here entirely and I implement it as a patch in conan.

Let me know what you think!

Best,
Sebastian