### PR TITLE
fix: DockFocusController doesn't pick up on old dock deletion outside of view

### DIFF
--- a/src/DockFocusController.cpp
+++ b/src/DockFocusController.cpp
@@ -42,7 +42,7 @@ struct DockFocusControllerPrivate
 	CDockFocusController *_this;
 	QPointer<CDockWidget> FocusedDockWidget = nullptr;
 	QPointer<CDockAreaWidget> FocusedArea = nullptr;
-	CDockWidget* OldFocusedDockWidget = nullptr;
+	QPointer<CDockWidget> OldFocusedDockWidget = nullptr;
 #ifdef Q_OS_LINUX
      QPointer<CFloatingDockContainer> FloatingWidget = nullptr;
 #endif


### PR DESCRIPTION
We have the following scenario:
- Two main views, one with the ADS, one without
- The second view can delete widgets displayed by the ADS in the first view

=> Open two widgets, focus the one you're about to delete
=> Change view, delete widget (which calls `takeWidget()` + `closeDockWidget()` from ADS), come back to ADS view
=> Crash inside `CDockFocusController::onDockWidgetVisibilityChanged` because `d->OldFocusedDockWidget` points to deleted memory

This MR fixes this by using a QPointer so when the event is called, `d->OldFocusedDockWidget` is `nullptr`.