### PR TITLE
Allow to set a custom title for all FloatingContainer

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -287,7 +287,8 @@ current dock widget.
 
 ![FloatingContainerHasWidgetTitle true](cfg_flag_FloatingContainerHasWidgetTitle_true.png)
 
-otherwise it displays application name as window title.
+otherwise it displays the title set with `CDockManager::setFloatingContainersTitle` or
+application name as window title.
 
 ![FloatingContainerHasWidgetTitle false](cfg_flag_FloatingContainerHasWidgetTitle_false.png)
 

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -92,6 +92,8 @@ enum eStateFileVersion
 
 static CDockManager::ConfigFlags StaticConfigFlags = CDockManager::DefaultNonOpaqueConfig;
 
+static QString FloatingContainersTitle;
+
 /**
  * Private data class of CDockManager class (pimpl)
  */
@@ -1253,6 +1255,21 @@ void CDockManager::setSplitterSizes(CDockAreaWidget *ContainedArea, const QList<
 CDockFocusController* CDockManager::dockFocusController() const
 {
 	return d->FocusController;
+}
+
+//===========================================================================
+void CDockManager::setFloatingContainersTitle(const QString& Title)
+{
+	FloatingContainersTitle = Title;
+}
+
+//===========================================================================
+QString CDockManager::floatingContainersTitle()
+{
+	if (FloatingContainersTitle.isEmpty())
+		return qApp->applicationDisplayName();
+
+	return FloatingContainersTitle;
 }
 
 } // namespace ads

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -186,7 +186,7 @@ public:
 		DockAreaHasTabsMenuButton = 0x8000,     //!< If the flag is set each dock area has a tabs menu button
 		DockAreaHideDisabledButtons = 0x10000,    //!< If the flag is set disabled dock area buttons will not appear on the toolbar at all (enabling them will bring them back)
 		DockAreaDynamicTabsMenuButtonVisibility = 0x20000, //!< If the flag is set, the tabs menu button will be shown only when it is required - that means, if the tabs are elided. If the tabs are not elided, it is hidden
-		FloatingContainerHasWidgetTitle = 0x40000, //!< If set, the Floating Widget window title reflects the title of the current dock widget otherwise it displays application name as window title
+		FloatingContainerHasWidgetTitle = 0x40000, //!< If set, the Floating Widget window title reflects the title of the current dock widget otherwise it displays the title set with `CDockManager::setFloatingContainersTitle` or application name as window title
 		FloatingContainerHasWidgetIcon = 0x80000, //!< If set, the Floating Widget icon reflects the icon of the current dock widget otherwise it displays application icon
 		HideSingleCentralWidgetTitleBar = 0x100000, //!< If there is only one single visible dock widget in the main dock container (the dock manager) and if this flag is set, then the titlebar of this dock widget will be hidden
 		                                            //!< this only makes sense for non draggable and non floatable widgets and enables the creation of some kind of "central" widget
@@ -527,6 +527,21 @@ public:
      * effect.
      */
     void setSplitterSizes(CDockAreaWidget *ContainedArea, const QList<int>& sizes);
+
+	/**
+	 * Set a custom title for all FloatingContainer that does not reflect
+	 * the title of the current dock widget.
+	 */
+	static void setFloatingContainersTitle(const QString& Title);
+
+	/**
+	 * Returns the title used by all FloatingContainer that does not
+	 * reflect the title of the current dock widget.
+	 *
+	 * If not title was set with setFloatingContainersTitle(), it returns
+	 * QGuiApplication::applicationDisplayName().
+	 */
+	static QString floatingContainersTitle();
 
 public Q_SLOTS:
 	/**

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -433,7 +433,7 @@ struct FloatingDockContainerPrivate
 		}
 		else
 		{
-			setWindowTitle(qApp->applicationDisplayName());
+			setWindowTitle(floatingContainersTitle());
 		}
 
 		// reflect CurrentWidget's icon if configured to do so, otherwise display application icon as window icon
@@ -453,6 +453,18 @@ struct FloatingDockContainerPrivate
 	 * Handles escape key press when dragging around the floating widget
 	 */
 	void handleEscapeKey();
+
+	/**
+	 * Returns the title used by all FloatingContainer that does not
+	 * reflect the title of the current dock widget.
+	 *
+	 * If not title was set with CDockManager::setFloatingContainersTitle(),
+	 * it returns QGuiApplication::applicationDisplayName().
+	 */
+	static QString floatingContainersTitle()
+	{
+		return CDockManager::floatingContainersTitle();
+	}
 };
 // struct FloatingDockContainerPrivate
 
@@ -985,7 +997,7 @@ void CFloatingDockContainer::onDockAreasAddedOrRemoved()
 			    SLOT(onDockAreaCurrentChanged(int)));
 			d->SingleDockArea = nullptr;
 		}
-		d->setWindowTitle(qApp->applicationDisplayName());
+		d->setWindowTitle(d->floatingContainersTitle());
 		setWindowIcon(QApplication::windowIcon());
 	}
 }
@@ -1012,7 +1024,7 @@ void CFloatingDockContainer::updateWindowTitle()
 	}
 	else
 	{
-		d->setWindowTitle(qApp->applicationDisplayName());
+		d->setWindowTitle(d->floatingContainersTitle());
 		setWindowIcon(QApplication::windowIcon());
 	}
 }


### PR DESCRIPTION
Allow to set a custom title for all FloatingContainer that does not reflect the title of the current dock widget rather than directly falling back to `QGuiApplication::applicationDisplayName()`.