### PR TITLE
include <functional> to fix mingw build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,3 +384,4 @@ FodyWeavers.xsd
 /Settings.ini
 .vscode/settings.json
 /.settings
+compile_commands.json

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
-project(ads_demo VERSION ${VERSION_SHORT}) 
+project(ads_demo VERSION ${VERSION_SHORT})
 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
+
 if(WIN32 AND QT_VERSION_MAJOR LESS 6)
     find_package(Qt${QT_VERSION_MAJOR} COMPONENTS AxContainer REQUIRED)
 endif()
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(ads_demo_SRCS
     main.cpp
@@ -13,18 +15,20 @@ set(ads_demo_SRCS
     mainwindow.ui
     StatusDialog.cpp
     StatusDialog.ui
-	demo.qrc
+    demo.qrc
 )
 add_executable(AdvancedDockingSystemDemo WIN32 ${ads_demo_SRCS})
 target_include_directories(AdvancedDockingSystemDemo PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src")
-target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::Core 
-                                                       Qt${QT_VERSION_MAJOR}::Gui 
-                                                       Qt${QT_VERSION_MAJOR}::Widgets)
+target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets)
+
 if(WIN32 AND QT_VERSION_MAJOR LESS 6)
     target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::AxContainer)
 endif()
+
 target_link_libraries(AdvancedDockingSystemDemo PRIVATE qtadvanceddocking)
-set_target_properties(AdvancedDockingSystemDemo PROPERTIES 
+set_target_properties(AdvancedDockingSystemDemo PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     AUTOUIC ON
@@ -33,11 +37,11 @@ set_target_properties(AdvancedDockingSystemDemo PROPERTIES
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "Qt Advanced Docking System Demo"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
-#if(BUILD_STATIC)
-#    target_compile_definitions(AdvancedDockingSystemDemo PRIVATE ADS_STATIC)
-#endif()
 
+# if(BUILD_STATIC)
+# target_compile_definitions(AdvancedDockingSystemDemo PRIVATE ADS_STATIC)
+# endif()

--- a/examples/centralwidget/CMakeLists.txt
+++ b/examples/centralwidget/CMakeLists.txt
@@ -1,19 +1,19 @@
 cmake_minimum_required(VERSION 3.5)
-project(ads_example_centralwidget VERSION ${VERSION_SHORT}) 
+project(ads_example_centralwidget VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-add_executable(CentralWidgetExample WIN32 
+add_executable(CentralWidgetExample WIN32
     main.cpp
     mainwindow.cpp
     mainwindow.ui
 )
 target_include_directories(CentralWidgetExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(CentralWidgetExample PRIVATE qtadvanceddocking)
-target_link_libraries(CentralWidgetExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
-                                                  Qt${QT_VERSION_MAJOR}::Gui 
-                                                  Qt${QT_VERSION_MAJOR}::Widgets)
-set_target_properties(CentralWidgetExample PROPERTIES 
+target_link_libraries(CentralWidgetExample PUBLIC Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets)
+set_target_properties(CentralWidgetExample PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     AUTOUIC ON
@@ -22,7 +22,7 @@ set_target_properties(CentralWidgetExample PROPERTIES
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "Qt Advanced Docking System Central Widget Example"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )

--- a/examples/deleteonclose/CMakeLists.txt
+++ b/examples/deleteonclose/CMakeLists.txt
@@ -1,24 +1,24 @@
 cmake_minimum_required(VERSION 3.5)
-project(ads_example_deleteonclose VERSION ${VERSION_SHORT}) 
+project(ads_example_deleteonclose VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-add_executable(DeleteOnCloseTest WIN32 
+add_executable(DeleteOnCloseTest WIN32
     main.cpp
 )
 target_include_directories(DeleteOnCloseTest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(DeleteOnCloseTest PRIVATE qtadvanceddocking)
-target_link_libraries(DeleteOnCloseTest PUBLIC Qt${QT_VERSION_MAJOR}::Core 
-                                               Qt${QT_VERSION_MAJOR}::Gui 
-                                               Qt${QT_VERSION_MAJOR}::Widgets)
-set_target_properties(DeleteOnCloseTest PROPERTIES 
+target_link_libraries(DeleteOnCloseTest PUBLIC Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets)
+set_target_properties(DeleteOnCloseTest PROPERTIES
     AUTOMOC ON
     CXX_STANDARD 14
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "Qt Advanced Docking System Delete on Close Example"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )

--- a/examples/dockindock/CMakeLists.txt
+++ b/examples/dockindock/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
-project(ads_example_dockindock VERSION ${VERSION_SHORT}) 
+project(ads_example_dockindock VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-add_executable(DockInDockExample WIN32 
+add_executable(DockInDockExample WIN32
     dockindock.cpp
     dockindockmanager.cpp
     perspectiveactions.cpp
@@ -13,10 +13,10 @@ add_executable(DockInDockExample WIN32
 )
 target_include_directories(DockInDockExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(DockInDockExample PRIVATE qtadvanceddocking)
-target_link_libraries(DockInDockExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
-                                           Qt${QT_VERSION_MAJOR}::Gui 
-                                           Qt${QT_VERSION_MAJOR}::Widgets)
-set_target_properties(DockInDockExample PROPERTIES 
+target_link_libraries(DockInDockExample PUBLIC Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets)
+set_target_properties(DockInDockExample PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     AUTOUIC ON
@@ -25,7 +25,7 @@ set_target_properties(DockInDockExample PROPERTIES
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "Qt Advanced Docking System Simple Example"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )

--- a/examples/emptydockarea/CMakeLists.txt
+++ b/examples/emptydockarea/CMakeLists.txt
@@ -1,19 +1,19 @@
 cmake_minimum_required(VERSION 3.5)
-project(ads_example_centralwidget VERSION ${VERSION_SHORT}) 
+project(ads_example_centralwidget VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-add_executable(EmptyDockAreaExample WIN32 
+add_executable(EmptyDockAreaExample WIN32
     main.cpp
     mainwindow.cpp
     mainwindow.ui
 )
 target_include_directories(EmptyDockAreaExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(EmptyDockAreaExample PRIVATE qtadvanceddocking)
-target_link_libraries(EmptyDockAreaExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
-                                                  Qt${QT_VERSION_MAJOR}::Gui 
-                                                  Qt${QT_VERSION_MAJOR}::Widgets)
-set_target_properties(EmptyDockAreaExample PROPERTIES 
+target_link_libraries(EmptyDockAreaExample PUBLIC Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets)
+set_target_properties(EmptyDockAreaExample PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     AUTOUIC ON
@@ -22,7 +22,7 @@ set_target_properties(EmptyDockAreaExample PROPERTIES
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "Qt Advanced Docking System Empty Dock Area Example"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )

--- a/examples/hideshow/CMakeLists.txt
+++ b/examples/hideshow/CMakeLists.txt
@@ -1,19 +1,19 @@
 cmake_minimum_required(VERSION 3.5)
-project(ads_example_hideshow VERSION ${VERSION_SHORT}) 
+project(ads_example_hideshow VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-add_executable(HideShowExample WIN32 
+add_executable(HideShowExample WIN32
     main.cpp
     MainWindow.cpp
     MainWindow.ui
 )
 target_include_directories(HideShowExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(HideShowExample PRIVATE qtadvanceddocking)
-target_link_libraries(HideShowExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
-                                             Qt${QT_VERSION_MAJOR}::Gui 
-                                             Qt${QT_VERSION_MAJOR}::Widgets)
-set_target_properties(HideShowExample PROPERTIES 
+target_link_libraries(HideShowExample PUBLIC Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets)
+set_target_properties(HideShowExample PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     AUTOUIC ON
@@ -22,7 +22,7 @@ set_target_properties(HideShowExample PROPERTIES
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "Qt Advanced Docking System Hide,Show Example"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )

--- a/examples/sidebar/CMakeLists.txt
+++ b/examples/sidebar/CMakeLists.txt
@@ -1,19 +1,19 @@
 cmake_minimum_required(VERSION 3.5)
-project(ads_example_sidebar VERSION ${VERSION_SHORT}) 
+project(ads_example_sidebar VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-add_executable(SidebarExample WIN32 
+add_executable(SidebarExample WIN32
     main.cpp
     MainWindow.cpp
     MainWindow.ui
 )
 target_include_directories(SidebarExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(SidebarExample PRIVATE qtadvanceddocking)
-target_link_libraries(SidebarExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
-                                            Qt${QT_VERSION_MAJOR}::Gui 
-                                            Qt${QT_VERSION_MAJOR}::Widgets)
-set_target_properties(SidebarExample PROPERTIES 
+target_link_libraries(SidebarExample PUBLIC Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets)
+set_target_properties(SidebarExample PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     AUTOUIC ON
@@ -22,7 +22,7 @@ set_target_properties(SidebarExample PROPERTIES
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "Qt Advanced Docking System Sidebar Example"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,19 +1,19 @@
 cmake_minimum_required(VERSION 3.5)
-project(ads_example_simple VERSION ${VERSION_SHORT}) 
+project(ads_example_simple VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-add_executable(SimpleExample WIN32 
+add_executable(SimpleExample WIN32
     main.cpp
     MainWindow.cpp
     MainWindow.ui
 )
 target_include_directories(SimpleExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(SimpleExample PRIVATE qtadvanceddocking)
-target_link_libraries(SimpleExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
-                                           Qt${QT_VERSION_MAJOR}::Gui 
-                                           Qt${QT_VERSION_MAJOR}::Widgets)
-set_target_properties(SimpleExample PROPERTIES 
+target_link_libraries(SimpleExample PUBLIC Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets)
+set_target_properties(SimpleExample PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     AUTOUIC ON
@@ -22,7 +22,7 @@ set_target_properties(SimpleExample PROPERTIES
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "Qt Advanced Docking System Simple Example"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,13 +2,17 @@ cmake_minimum_required(VERSION 3.5)
 project(QtAdvancedDockingSystem LANGUAGES CXX VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Widgets REQUIRED)
-if (UNIX AND NOT APPLE)
+
+if(UNIX AND NOT APPLE)
     include_directories(${Qt${QT_VERSION_MAJOR}Gui_PRIVATE_INCLUDE_DIRS})
 endif()
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 if(BUILD_STATIC)
     set(CMAKE_STATIC_LIBRARY_SUFFIX "_static${CMAKE_STATIC_LIBRARY_SUFFIX}")
 endif()
+
 set(ads_SRCS
     ads_globals.cpp
     DockAreaTabBar.cpp
@@ -50,10 +54,12 @@ set(ads_HEADERS
     DockComponentsFactory.h
 )
 add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
-if (UNIX AND NOT APPLE)
+
+if(UNIX AND NOT APPLE)
     set(ads_SRCS linux/FloatingWidgetTitleBar.cpp ${ads_SRCS})
     set(ads_HEADERS linux/FloatingWidgetTitleBar.h ${ads_HEADERS})
 endif()
+
 if(BUILD_STATIC)
     add_library(qtadvanceddocking STATIC ${ads_SRCS} ${ads_HEADERS})
     target_compile_definitions(qtadvanceddocking PUBLIC ADS_STATIC)
@@ -64,22 +70,25 @@ endif()
 
 add_library(ads::qtadvanceddocking ALIAS qtadvanceddocking)
 
-target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core 
-                                               Qt${QT_VERSION_MAJOR}::Gui 
-                                               Qt${QT_VERSION_MAJOR}::Widgets)
-if (UNIX AND NOT APPLE)
-  target_link_libraries(qtadvanceddocking PUBLIC xcb)
+target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets)
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(qtadvanceddocking PUBLIC xcb)
 endif()
+
 set_target_properties(qtadvanceddocking PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
     EXPORT_NAME "qtadvanceddocking"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
+
 if(QT_VERSION_MAJOR STREQUAL "5")
     set_target_properties(qtadvanceddocking PROPERTIES
         CXX_STANDARD 14

--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -190,6 +190,8 @@ public:
 		{
 			parent->setUpdatesEnabled(true);
 		}
+		if(m_CurrentWidget)
+			m_CurrentWidget->setFocus();
 	}
 
 	/**

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -1,4 +1,4 @@
-#ifndef DockWidgetH
+﻿#ifndef DockWidgetH
 #define DockWidgetH
 /*******************************************************************************
 ** Qt Advanced Docking System
@@ -31,6 +31,7 @@
 //                                   INCLUDES
 //============================================================================
 #include <QFrame>
+#include <functional>
 
 #include "ads_globals.h"
 


### PR DESCRIPTION
Get following error while compiling with ming64 :
DockWidget.h:283:34: error: 'function' in namespace 'std' does not name a template type
  283 |         using FactoryFunc = std::function<QWidget*(QWidget*)>;
      |                                  ^~~~~~~~
note: 'std::function' is defined in header '<functional>'; did you forget to '#include <functional>'?
   33 | #include <QFrame>
  +++ |+#include <functional>
   34 |