### PR TITLE
WIP: Adaption of PyQt5 bindings to Qt-ADS 4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 # Specify the build system.
 [build-system]
-requires = ["sip >=6.0.2, <6.6", "PyQt-builder >=1.6, <2", "PyQt5>=5.15.4", "PyQt5-sip<13,>=12.8"]
+requires = ["sip >=6.0.2, <6.3", "PyQt-builder >=1.6, <2", "PyQt5==5.15.4", "PyQt5-sip<13,>=12.8"]
 build-backend = "sipbuild.api"
 
 # Specify the PEP 566 metadata for the project.
 [tool.sip.metadata]
 name = "PyQtAds"
-version = "3.8.2"
+version = "4.0.0"
 summary = "Python bindings for Qt Advanced Docking System"
 home-page = "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/"
 license = "LGPL v2.1"
@@ -23,6 +23,9 @@ sip-file = "ads.sip"
 include-dirs = ["src"]
 qmake-QT = ["widgets"]
 headers = [
+	"src/AutoHideDockContainer.h",
+	"src/AutoHideSideBar.h",
+	"src/AutoHideTab.h",
 	"src/DockAreaTabBar.h",
 	"src/DockAreaTitleBar.h",
 	"src/DockAreaTitleBar_p.h",
@@ -40,10 +43,15 @@ headers = [
 	"src/FloatingDockContainer.h",
 	"src/FloatingDragPreview.h",
 	"src/IconProvider.h",
+	"src/PushButton.h",
+	"src/ResizeHandle.h",
 	"src/ads_globals.h",
 	# "src/linux/FloatingWidgetTitleBar.h",
 ]
 sources = [
+	"src/AutoHideDockContainer.cpp",
+	"src/AutoHideSideBar.cpp",
+	"src/AutoHideTab.cpp",
 	"src/DockAreaTabBar.cpp",
 	"src/DockAreaTitleBar.cpp",
 	"src/DockAreaWidget.cpp",
@@ -60,6 +68,8 @@ sources = [
 	"src/FloatingDockContainer.cpp",
 	"src/FloatingDragPreview.cpp",
 	"src/IconProvider.cpp",
+	"src/PushButton.cpp",
+	"src/ResizeHandle.cpp",
 	"src/ads_globals.cpp",
 	# "src/linux/FloatingWidgetTitleBar.cpp",
 ]

--- a/sip/DockContainerWidget.sip
+++ b/sip/DockContainerWidget.sip
@@ -53,7 +53,8 @@ public:
 	 * \return Returns the dock area widget that contains the new DockWidget
 	 */
 	ads::CDockAreaWidget* addDockWidget(ads::DockWidgetArea area, ads::CDockWidget* Dockwidget /Transfer/,
-		ads::CDockAreaWidget* DockAreaWidget /Transfer/ = 0);
+		ads::CDockAreaWidget* DockAreaWidget /Transfer/ = 0,
+		int Index = -1);
 
 	/**
 	 * Removes dockwidget

--- a/sip/DockManager.sip
+++ b/sip/DockManager.sip
@@ -180,6 +180,17 @@ public:
 		NonOpaqueWithWindowFrame,
 	};
     typedef QFlags<ads::CDockManager::eConfigFlag> ConfigFlags;
+	enum eAutoHideFlag
+	{
+		AutoHideFeatureEnabled,
+		DockAreaHasAutoHideButton,
+		AutoHideButtonTogglesArea,
+		AutoHideButtonCheckable,
+		AutoHideSideBarsIconOnly,
+		AutoHideShowOnMouseOver,
+		DefaultAutoHideConfig,
+	};
+    typedef QFlags<ads::CDockManager::eAutoHideFlag> AutoHideFlags;
 
 	CDockManager(QWidget* parent /TransferThis/ = 0);
 	virtual ~CDockManager();
@@ -187,13 +198,22 @@ public:
 	static void setConfigFlags(const ads::CDockManager::ConfigFlags Flags);
 	static void setConfigFlag(ads::CDockManager::eConfigFlag Flag, bool On = true);
 	static bool testConfigFlag(eConfigFlag Flag);
+	static ads::CDockManager::AutoHideFlags autoHideConfigFlags();
+	static void setAutoHideConfigFlags(const ads::CDockManager::AutoHideFlags Flags);
+	static void setAutoHideConfigFlag(ads::CDockManager::eAutoHideFlag Flag, bool On = true);
+	static bool testAutoHideConfigFlag(eAutoHideFlag Flag);
     static ads::CIconProvider& iconProvider();
 	ads::CDockAreaWidget* addDockWidget(ads::DockWidgetArea area, ads::CDockWidget* Dockwidget /Transfer/,
-		ads::CDockAreaWidget* DockAreaWidget /Transfer/ = 0);
+		ads::CDockAreaWidget* DockAreaWidget /Transfer/ = 0,
+		int Index = -1);
+	ads::CDockAreaWidget* addDockWidgetToContainer(ads::DockWidgetArea area, ads::CDockWidget* Dockwidget /Transfer/,
+		ads::CDockContainerWidget* DockContainerWidget /Transfer/ = 0);
+
 	ads::CDockAreaWidget* addDockWidgetTab(ads::DockWidgetArea area,
 		ads::CDockWidget* Dockwidget /Transfer/);
 	ads::CDockAreaWidget* addDockWidgetTabToArea(ads::CDockWidget* Dockwidget /Transfer/,
-		ads::CDockAreaWidget* DockAreaWidget /Transfer/);
+		ads::CDockAreaWidget* DockAreaWidget /Transfer/,
+		int Index = -1);
     ads::CFloatingDockContainer* addDockWidgetFloating(ads::CDockWidget* DockWidget /Transfer/);
 	ads::CDockWidget* findDockWidget(const QString& ObjectName) const;
 	void removeDockWidget(ads::CDockWidget* Dockwidget) /TransferBack/;


### PR DESCRIPTION
Hi,
I'm working on releasing a new version of the PyQtAds package. Currently I've not yet added all the new API to the SIP files.

I've added so far:
 * CDockManager
    * autoHideConfigFlags
    * setAutoHideConfigFlags
    * setAutoHideConfigFlag
    * testAutoHideConfigFlag
    * addDockWidgetToContainer
    * Index parameter on addDockWidget and addDockWidgetTabToArea
 * CDockContainerWidget
   *  Index parameter on addDockWidget

Do you have an idea how to get a good overview about any other API changes?
