### PR TITLE
Fix crash caused by dockContainerWidget not removing auto hide dock

### DIFF
--- a/src/AutoHideDockContainer.cpp
+++ b/src/AutoHideDockContainer.cpp
@@ -187,14 +187,7 @@ AutoHideDockContainerPrivate::AutoHideDockContainerPrivate(
 //============================================================================
 CDockContainerWidget* CAutoHideDockContainer::dockContainer() const
 {
-	if (d->DockArea)
-	{
-		return d->DockArea->dockContainer();
-	}
-	else
-	{
-		return internal::findParent<CDockContainerWidget*>(this);
-	}
+	return internal::findParent<CDockContainerWidget*>(this);
 }
 
 


### PR DESCRIPTION
Hi @githubuser0xFFFF, thanks for releasing the Auto hide feature :). This is a small fix for a crash that I found. Here's how to reproduce it:

1) If you have two windows and the sub window has an auto hide widget:
![image](https://user-images.githubusercontent.com/4475295/206339830-b9dcc359-70f0-4f3e-b267-f25bb83ab838.png)

2) If you press right click and then "detach" the auto hide container:
![image](https://user-images.githubusercontent.com/4475295/206340019-5249ec70-6b48-4223-9e34-8410c8d768fc.png)

3) Then you delete the previous window:
![image](https://user-images.githubusercontent.com/4475295/206340113-6833ab8d-e6fc-4aca-9f1a-1ce2c2fe064f.png)


You'll get a crash. I believe this is being caused by the destructor of the AutoHideDockContainer not removing the correct registered auto hide widget from the correct container:

![image](https://user-images.githubusercontent.com/4475295/206340335-ac648865-43c2-42da-b388-0d40783b9380.png)

You can see that dockContainer() is getting the dockArea->dockContainer(), which has already been detached. It should try to remove only it's parent dockContainer():

![image](https://user-images.githubusercontent.com/4475295/206340547-5b2f3e3b-3753-484a-a504-84f3d5918f97.png)


