### PR TITLE
Draggable autohide tab

### DIFF
--- a/src/AutoHideDockContainer.cpp
+++ b/src/AutoHideDockContainer.cpp
@@ -199,7 +199,7 @@ CAutoHideDockContainer::CAutoHideDockContainer(CDockWidget* DockWidget, SideBarL
 	hide(); // auto hide dock container is initially always hidden
 	d->SideTabBarArea = area;
 	d->SideTab = componentsFactory()->createDockWidgetSideTab(nullptr);
-	connect(d->SideTab, &CAutoHideTab::pressed, this, &CAutoHideDockContainer::toggleCollapseState);
+	connect(d->SideTab, &CAutoHideTab::released, this, &CAutoHideDockContainer::toggleCollapseState);
 	d->DockArea = new CDockAreaWidget(DockWidget->dockManager(), parent);
 	d->DockArea->setObjectName("autoHideDockArea");
 	d->DockArea->setAutoHideDockContainer(this);
@@ -540,7 +540,7 @@ bool CAutoHideDockContainer::eventFilter(QObject* watched, QEvent* event)
 			updateSize();
 		}
 	}
-	else if (event->type() == QEvent::MouseButtonPress)
+	else if (event->type() == QEvent::MouseButtonRelease)
 	{
 		auto widget = qobject_cast<QWidget*>(watched);
 		// Ignore non widget events

--- a/src/AutoHideSideBar.cpp
+++ b/src/AutoHideSideBar.cpp
@@ -52,10 +52,10 @@ class CTabsWidget;
  */
 struct AutoHideSideBarPrivate
 {
-	/**
-	 * Private data constructor
-	 */
-	AutoHideSideBarPrivate(CAutoHideSideBar* _public);
+  /**
+   * Private data constructor
+   */
+  AutoHideSideBarPrivate(CAutoHideSideBar* _public);
 
     CAutoHideSideBar* _this;
     CDockContainerWidget* ContainerWidget;
@@ -63,19 +63,30 @@ struct AutoHideSideBarPrivate
     QBoxLayout* TabsLayout;
     Qt::Orientation Orientation;
     SideBarLocation SideTabArea = SideBarLocation::SideBarLeft;
+    CAutoHideTab* PlaceholderTab;
 
     /**
      * Convenience function to check if this is a horizontal side bar
      */
     bool isHorizontal() const
     {
-    	return Qt::Horizontal == Orientation;
+      return Qt::Horizontal == Orientation;
     }
 
     /**
      * Called from viewport to forward event handling to this
      */
     void handleViewportEvent(QEvent* e);
+
+    /**
+    * Convenience function to access first tab
+    */
+    CAutoHideTab* firstTab() const {return _this->tab(0);}
+
+    /**
+    * Convenience function to access last tab
+    */
+    CAutoHideTab* lastTab() const {return _this->tab(_this->tabCount() - 1);}
 }; // struct AutoHideSideBarPrivate
 
 
@@ -85,72 +96,74 @@ struct AutoHideSideBarPrivate
 class CTabsWidget : public QWidget
 {
 public:
-	using QWidget::QWidget;
-	using Super = QWidget;
-	AutoHideSideBarPrivate* EventHandler;
+  using QWidget::QWidget;
+  using Super = QWidget;
+  AutoHideSideBarPrivate* EventHandler;
 
-	/**
-	 * Returns the size hint as minimum size hint
-	 */
-	virtual QSize minimumSizeHint() const override
-	{
-		return Super::sizeHint();
-	}
+  /**
+   * Returns the size hint as minimum size hint
+   */
+  virtual QSize minimumSizeHint() const override
+  {
+    return Super::sizeHint();
+  }
 
-	/**
-	 * Forward event handling to EventHandler
-	 */
-	virtual bool event(QEvent* e) override
-	{
-		EventHandler->handleViewportEvent(e);
-		return Super::event(e);
-	}
+  /**
+   * Forward event handling to EventHandler
+   */
+  virtual bool event(QEvent* e) override
+  {
+    EventHandler->handleViewportEvent(e);
+    return Super::event(e);
+  }
 };
 
 
 //============================================================================
 AutoHideSideBarPrivate::AutoHideSideBarPrivate(CAutoHideSideBar* _public) :
-    _this(_public)
+    _this(_public),
+    PlaceholderTab(new CAutoHideTab(_this))
 {
+    PlaceholderTab->hide();
 }
 
 
 //============================================================================
 void AutoHideSideBarPrivate::handleViewportEvent(QEvent* e)
 {
-	switch (e->type())
-	{
-	case QEvent::ChildRemoved:
-		if (TabsLayout->isEmpty())
-		{
-			_this->hide();
-		}
-		break;
+  switch (e->type())
+  {
+  case QEvent::ChildRemoved:
+    if (TabsLayout->isEmpty())
+    {
+      _this->hide();
+    }
+    break;
 
-	case QEvent::Resize:
-		if (_this->tabCount())
-		{
-			auto ev = static_cast<QResizeEvent*>(e);
-			auto Tab = _this->tabAt(0);
-			int Size = isHorizontal() ? ev->size().height() : ev->size().width();
-			int TabSize = isHorizontal() ? Tab->size().height() : Tab->size().width();
-			// If the size of the side bar is less than the size of the first tab
-			// then there are no visible tabs in this side bar. This check will
-			// fail if someone will force a very big border via CSS!!
-			if (Size < TabSize)
-			{
-				_this->hide();
-			}
-		}
-		else
-		{
-			_this->hide();
-		}
-		break;
+  case QEvent::Resize:
+    if (_this->tabCount())
+    {
+      auto ev = static_cast<QResizeEvent*>(e);
+      auto Tab = _this->tabAt(0);
+      int Size = isHorizontal() ? ev->size().height() : ev->size().width();
+      int TabSize = isHorizontal() ? Tab->size().height() : Tab->size().width();
+      // If the size of the side bar is less than the size of the first tab
+      // then there are no visible tabs in this side bar. This check will
+      // fail if someone will force a very big border via CSS!!
+      if (Size < TabSize)
+      {
+        _this->hide();
+      }
+    }
+    else
+    {
+      _this->hide();
+    }
+    break;
 
-	default:
-		break;
-	}
+  default:
+    break;
+  }
 }
 
 
@@ -159,56 +172,56 @@ CAutoHideSideBar::CAutoHideSideBar(CDockContainerWidget* parent, SideBarLocation
     Super(parent),
     d(new AutoHideSideBarPrivate(this))
 {
-	d->SideTabArea = area;
-    d->ContainerWidget = parent;
-    d->Orientation = (area == SideBarLocation::SideBarBottom || area == SideBarLocation::SideBarTop)
-    	? Qt::Horizontal : Qt::Vertical;
+  d->SideTabArea = area;
+  d->ContainerWidget = parent;
+  d->Orientation = (area == SideBarLocation::SideBarBottom || area == SideBarLocation::SideBarTop)
+  ? Qt::Horizontal : Qt::Vertical;
 
-	setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-	setFrameStyle(QFrame::NoFrame);
-	setWidgetResizable(true);
-	setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-	setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+  setFrameStyle(QFrame::NoFrame);
+  setWidgetResizable(true);
+  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-	d->TabsContainerWidget = new CTabsWidget();
-	d->TabsContainerWidget->EventHandler = d;
-	d->TabsContainerWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-	d->TabsContainerWidget->setObjectName("sideTabsContainerWidget");
+  d->TabsContainerWidget = new CTabsWidget();
+  d->TabsContainerWidget->EventHandler = d;
+  d->TabsContainerWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+  d->TabsContainerWidget->setObjectName("sideTabsContainerWidget");
 
 
-    d->TabsLayout = new QBoxLayout(d->Orientation == Qt::Vertical ? QBoxLayout::TopToBottom : QBoxLayout::LeftToRight);
-    d->TabsLayout->setContentsMargins(0, 0, 0, 0);
-    d->TabsLayout->setSpacing(12);
-    d->TabsLayout->addStretch(1);
-    d->TabsContainerWidget->setLayout(d->TabsLayout);
-	setWidget(d->TabsContainerWidget);
+  d->TabsLayout = new QBoxLayout(d->Orientation == Qt::Vertical ? QBoxLayout::TopToBottom : QBoxLayout::LeftToRight);
+  d->TabsLayout->setContentsMargins(0, 0, 0, 0);
+  d->TabsLayout->setSpacing(12);
+  d->TabsLayout->addStretch(1);
+  d->TabsContainerWidget->setLayout(d->TabsLayout);
+  setWidget(d->TabsContainerWidget);
 
     setFocusPolicy(Qt::NoFocus);
-	if (d->isHorizontal())
-	{
-		setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-	}
-	else
-	{
-		setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
-	}
+  if (d->isHorizontal())
+  {
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  }
+  else
+  {
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+  }
 
-	hide();
+  hide();
 }
 
 
 //============================================================================
 CAutoHideSideBar::~CAutoHideSideBar() 
 {
-	ADS_PRINT("~CSideTabBar()");
-	// The SideTabeBar is not the owner of the tabs and to prevent deletion
-	// we set the parent here to nullptr to remove it from the children
-	auto Tabs = findChildren<CAutoHideTab*>(QString(), Qt::FindDirectChildrenOnly);
-	for (auto Tab : Tabs)
-	{
-		Tab->setParent(nullptr);
-	}
-	delete d;
+  ADS_PRINT("~CSideTabBar()");
+  // The SideTabeBar is not the owner of the tabs and to prevent deletion
+  // we set the parent here to nullptr to remove it from the children
+  auto Tabs = findChildren<CAutoHideTab*>(QString(), Qt::FindDirectChildrenOnly);
+  for (auto Tab : Tabs)
+  {
+    Tab->setParent(nullptr);
+  }
+  delete d;
 }
 
 
@@ -216,14 +229,16 @@ CAutoHideSideBar::~CAutoHideSideBar()
 void CAutoHideSideBar::insertTab(int Index, CAutoHideTab* SideTab)
 {
     SideTab->setSideBar(this);
-	SideTab->installEventFilter(this);
+    SideTab->installEventFilter(this);
+    connect(SideTab, SIGNAL(moved(QPoint)), this, SLOT(onAutoHideTabMoved(QPoint)));
+    connect(SideTab, SIGNAL(moving(QPoint)), this, SLOT(onAutoHideTabMoving(QPoint)));
     if (Index < 0)
     {
-    	d->TabsLayout->insertWidget(d->TabsLayout->count() - 1, SideTab);
+      d->TabsLayout->insertWidget(d->TabsLayout->count() - 1, SideTab);
     }
     else
     {
-    	d->TabsLayout->insertWidget(Index, SideTab);
+      d->TabsLayout->insertWidget(Index, SideTab);
     }
     show();
 }
@@ -232,55 +247,55 @@ void CAutoHideSideBar::insertTab(int Index, CAutoHideTab* SideTab)
 //============================================================================
 CAutoHideDockContainer* CAutoHideSideBar::insertDockWidget(int Index, CDockWidget* DockWidget)
 {
-	auto AutoHideContainer = new CAutoHideDockContainer(DockWidget, d->SideTabArea, d->ContainerWidget);
-	DockWidget->dockManager()->dockFocusController()->clearDockWidgetFocus(DockWidget);
-	auto Tab = AutoHideContainer->autoHideTab();
-	DockWidget->setSideTabWidget(Tab);
-	insertTab(Index, Tab);
-	return AutoHideContainer;
+  auto AutoHideContainer = new CAutoHideDockContainer(DockWidget, d->SideTabArea, d->ContainerWidget);
+  DockWidget->dockManager()->dockFocusController()->clearDockWidgetFocus(DockWidget);
+  auto Tab = AutoHideContainer->autoHideTab();
+  DockWidget->setSideTabWidget(Tab);
+  insertTab(Index, Tab);
+  return AutoHideContainer;
 }
 
 
 //============================================================================
 void CAutoHideSideBar::removeAutoHideWidget(CAutoHideDockContainer* AutoHideWidget)
 {
-	AutoHideWidget->autoHideTab()->removeFromSideBar();
-	auto DockContainer = AutoHideWidget->dockContainer();
-	if (DockContainer)
-	{
-		DockContainer->removeAutoHideWidget(AutoHideWidget);
-	}
-	AutoHideWidget->setParent(nullptr);
+  AutoHideWidget->autoHideTab()->removeFromSideBar();
+  auto DockContainer = AutoHideWidget->dockContainer();
+  if (DockContainer)
+  {
+    DockContainer->removeAutoHideWidget(AutoHideWidget);
+  }
+  AutoHideWidget->setParent(nullptr);
 }
 
 //============================================================================
 void CAutoHideSideBar::addAutoHideWidget(CAutoHideDockContainer* AutoHideWidget)
 {
-	auto SideBar = AutoHideWidget->autoHideTab()->sideBar();
-	if (SideBar == this)
-	{
-		return;
-	}
+  auto SideBar = AutoHideWidget->autoHideTab()->sideBar();
+  if (SideBar == this)
+  {
+    return;
+  }
 
-	if (SideBar)
-	{
-		SideBar->removeAutoHideWidget(AutoHideWidget);
-	}
-	AutoHideWidget->setParent(d->ContainerWidget);
-	AutoHideWidget->setSideBarLocation(d->SideTabArea);
-	d->ContainerWidget->registerAutoHideWidget(AutoHideWidget);
-	insertTab(-1, AutoHideWidget->autoHideTab());
+  if (SideBar)
+  {
+    SideBar->removeAutoHideWidget(AutoHideWidget);
+  }
+  AutoHideWidget->setParent(d->ContainerWidget);
+  AutoHideWidget->setSideBarLocation(d->SideTabArea);
+  d->ContainerWidget->registerAutoHideWidget(AutoHideWidget);
+  insertTab(-1, AutoHideWidget->autoHideTab());
 }
 
 
 //============================================================================
 void CAutoHideSideBar::removeTab(CAutoHideTab* SideTab)
 {
-	SideTab->removeEventFilter(this);
+    SideTab->removeEventFilter(this);
     d->TabsLayout->removeWidget(SideTab);
     if (d->TabsLayout->isEmpty())
     {
-    	hide();
+      hide();
     }
 }
 
@@ -288,18 +303,18 @@ void CAutoHideSideBar::removeTab(CAutoHideTab* SideTab)
 //============================================================================
 bool CAutoHideSideBar::eventFilter(QObject *watched, QEvent *event)
 {
-	if (event->type() != QEvent::ShowToParent)
-	{
-		return false;
-	}
+    if (event->type() != QEvent::ShowToParent)
+    {
+        return false;
+    }
 
-	// As soon as on tab is shown, we need to show the side tab bar
-	auto Tab = qobject_cast<CAutoHideTab*>(watched);
-	if (Tab)
-	{
-		show();
-	}
-	return false;
+    // As soon as on tab is shown, we need to show the side tab bar
+    auto Tab = qobject_cast<CAutoHideTab*>(watched);
+    if (Tab)
+    {
+        show();
+    }
+    return false;
 }
 
 //============================================================================
@@ -326,71 +341,165 @@ int CAutoHideSideBar::tabCount() const
 //============================================================================
 SideBarLocation CAutoHideSideBar::sideBarLocation() const
 {
-	return d->SideTabArea;
+  return d->SideTabArea;
 }
 
 
 //============================================================================
 void CAutoHideSideBar::saveState(QXmlStreamWriter& s) const
 {
-	if (!tabCount())
-	{
-		return;
-	}
+  if (!tabCount())
+  {
+    return;
+  }
 
-	s.writeStartElement("SideBar");
-	s.writeAttribute("Area", QString::number(sideBarLocation()));
-	s.writeAttribute("Tabs", QString::number(tabCount()));
+  s.writeStartElement("SideBar");
+  s.writeAttribute("Area", QString::number(sideBarLocation()));
+  s.writeAttribute("Tabs", QString::number(tabCount()));
 
-	for (auto i = 0; i < tabCount(); ++i)
-	{
-		auto Tab = tabAt(i);
-		if (!Tab)
-		{
-			continue;
-		}
+  for (auto i = 0; i < tabCount(); ++i)
+  {
+    auto Tab = tabAt(i);
+    if (!Tab)
+    {
+      continue;
+    }
 
-		Tab->dockWidget()->autoHideDockContainer()->saveState(s);
-	}
+    Tab->dockWidget()->autoHideDockContainer()->saveState(s);
+  }
 
-	s.writeEndElement();
+  s.writeEndElement();
 }
 
 //===========================================================================
 QSize CAutoHideSideBar::minimumSizeHint() const
 {
-	QSize Size = sizeHint();
-	Size.setWidth(10);
-	return Size;
+  QSize Size = sizeHint();
+  Size.setWidth(10);
+  return Size;
 }
 
 
 //===========================================================================
 QSize CAutoHideSideBar::sizeHint() const
 {
-	return d->TabsContainerWidget->sizeHint();
+  return d->TabsContainerWidget->sizeHint();
 }
 
 
 //===========================================================================
 int CAutoHideSideBar::spacing() const
 {
-	return d->TabsLayout->spacing();
+  return d->TabsLayout->spacing();
 }
 
 
 //===========================================================================
 void CAutoHideSideBar::setSpacing(int Spacing)
 {
-	d->TabsLayout->setSpacing(Spacing);
+  d->TabsLayout->setSpacing(Spacing);
 }
 
 
 //===========================================================================
 CDockContainerWidget* CAutoHideSideBar::dockContainer() const
 {
-	return d->ContainerWidget;
+  return d->ContainerWidget;
 }
 
+
+//===========================================================================
+void CAutoHideSideBar::onAutoHideTabMoved(const QPoint& GlobalPos)
+{
+    auto MovingTab = qobject_cast<CAutoHideTab*>(sender());
+    if (!MovingTab)
+    {
+        return;
+    }
+
+    QSizePolicy sp_retain = d->PlaceholderTab->sizePolicy();
+    sp_retain.setRetainSizeWhenHidden(false);
+    d->PlaceholderTab->setSizePolicy(sp_retain);
+
+    // Swap the placeholder and the moved tab
+    const auto index = d->TabsLayout->indexOf(d->PlaceholderTab);
+    d->TabsLayout->removeWidget(d->PlaceholderTab);
+    d->TabsLayout->insertWidget(index, MovingTab);
+}
+
+
+//===========================================================================
+void CAutoHideSideBar::onAutoHideTabMoving(const QPoint& GlobalPos)
+{
+    auto MovingTab = qobject_cast<CAutoHideTab*>(sender());
+    if (!MovingTab)
+    {
+        return;
+    }
+
+    d->PlaceholderTab->setText(MovingTab->text());
+    d->PlaceholderTab->setOrientation(MovingTab->orientation());
+    QSizePolicy sp_retain = d->PlaceholderTab->sizePolicy();
+    sp_retain.setRetainSizeWhenHidden(true);
+    d->PlaceholderTab->setSizePolicy(sp_retain);
+    d->PlaceholderTab->setGeometry(MovingTab->geometry());
+
+    if (const auto index = d->TabsLayout->indexOf(MovingTab); index > -1)
+    {
+        // First time moving, set the placeholder tab into the moving tab position
+        d->TabsLayout->removeWidget(MovingTab);
+        d->TabsLayout->insertWidget(index, d->PlaceholderTab);
+    }
+
+    int fromIndex = d->TabsLayout->indexOf(d->PlaceholderTab);
+
+    auto MousePos = mapFromGlobal(GlobalPos);
+    MousePos.rx() = qMax(d->firstTab()->geometry().left(), MousePos.x());
+    MousePos.rx() = qMin(d->lastTab()->geometry().right(), MousePos.x());
+    MousePos.ry() = qMax(d->firstTab()->geometry().top(), MousePos.y());
+    MousePos.ry() = qMin(d->lastTab()->geometry().bottom(), MousePos.y());
+
+    int toIndex = -1;
+    // Find tab under mouse
+    for (int i = 0; i < tabCount(); ++i)
+    {
+        CAutoHideTab* DropTab = tab(i);
+        if (DropTab == d->PlaceholderTab || !DropTab->isVisibleTo(this)
+            || !DropTab->geometry().contains(MousePos)
+            )
+        {
+            continue;
+        }
+
+        toIndex = d->TabsLayout->indexOf(DropTab);
+        if (toIndex == fromIndex)
+        {
+            toIndex = -1;
+        }
+        break;
+    }
+
+    if (toIndex > -1)
+    {
+        d->TabsLayout->removeWidget(d->PlaceholderTab);
+        d->TabsLayout->insertWidget(toIndex, d->PlaceholderTab);
+    }
+    else
+    {
+        // Ensure that the moved tab is reset to its start position
+        d->TabsLayout->update();
+    }
+}
+
+
+//===========================================================================
+CAutoHideTab* CAutoHideSideBar::tab(int Index) const
+{
+	if (Index >= tabCount() || Index < 0)
+	{
+		return nullptr;
+	}
+	return qobject_cast<CAutoHideTab*>(d->TabsLayout->itemAt(Index)->widget());
+}
 } // namespace ads
 

--- a/src/AutoHideSideBar.cpp
+++ b/src/AutoHideSideBar.cpp
@@ -420,7 +420,8 @@ void CAutoHideSideBar::onAutoHideTabMoving(const QPoint &GlobalPos)
     sp_retain.setRetainSizeWhenHidden(true);
     d->PlaceholderTab->setSizePolicy(sp_retain);
 
-    if (const auto index = d->TabsLayout->indexOf(MovingTab); index > -1)
+    const auto index = d->TabsLayout->indexOf(MovingTab);
+    if (index > -1)
     {
         // First time moving, set the placeholder tab into the moving tab position
         d->TabsLayout->removeWidget(MovingTab);
@@ -443,7 +444,7 @@ void CAutoHideSideBar::onAutoHideTabMoving(const QPoint &GlobalPos)
         CAutoHideTab *DropTab = tab(i);
 
         // Truncate the geometry so that it will only switch if the mouse is still outside the tab after switching
-        // This prevents tab flickering while dragging
+        // This prevents the tab position flickering back and forth while dragging
         const auto geometry = DropTab->geometry();
         auto truncatedGeometry = geometry;
         if (d->PlaceholderTab->orientation() == Qt::Vertical)

--- a/src/AutoHideSideBar.h
+++ b/src/AutoHideSideBar.h
@@ -18,7 +18,6 @@
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-
 //============================================================================
 /// \file   AutoHideSideBar.h
 /// \author Syarif Fakhri
@@ -62,121 +61,121 @@ class ADS_EXPORT CAutoHideSideBar : public QScrollArea
     Q_PROPERTY(int spacing READ spacing WRITE setSpacing)
 
 private:
-    AutoHideSideBarPrivate* d; ///< private data (pimpl)
-	friend struct AutoHideSideBarPrivate;
-	friend class DockWidgetSideTab;
-	friend DockContainerWidgetPrivate;
-	friend CDockContainerWidget;
+    AutoHideSideBarPrivate *d; ///< private data (pimpl)
+    friend struct AutoHideSideBarPrivate;
+    friend class DockWidgetSideTab;
+    friend DockContainerWidgetPrivate;
+    friend CDockContainerWidget;
 
 private Q_SLOTS:
-    void onAutoHideTabMoved(const QPoint& GlobalPos);
-    void onAutoHideTabMoving(const QPoint& GlobalPos);
+    void onAutoHideTabMoved(const QPoint &GlobalPos);
+    void onAutoHideTabMoving(const QPoint &GlobalPos);
 
 protected:
-	virtual bool eventFilter(QObject *watched, QEvent *event) override;
+    virtual bool eventFilter(QObject *watched, QEvent *event) override;
 
-	/**
-	 * Saves the state into the given stream
-	 */
-	void saveState(QXmlStreamWriter& Stream) const;
+    /**
+     * Saves the state into the given stream
+     */
+    void saveState(QXmlStreamWriter &Stream) const;
 
-	/**
-	 * Inserts the given dock widget tab at the given position.
-	 * An Index value of -1 appends the side tab at the end.
-	 */
-	void insertTab(int Index, CAutoHideTab* SideTab);
+    /**
+     * Inserts the given dock widget tab at the given position.
+     * An Index value of -1 appends the side tab at the end.
+     */
+    void insertTab(int Index, CAutoHideTab *SideTab);
 
 public:
     using Super = QScrollArea;
 
-	/**
-	 * Default Constructor
-	 */
-    CAutoHideSideBar(CDockContainerWidget* parent, SideBarLocation area);
+    /**
+     * Default Constructor
+     */
+    CAutoHideSideBar(CDockContainerWidget *parent, SideBarLocation area);
 
-	/**
-	 * Virtual Destructor
-	 */
-	virtual ~CAutoHideSideBar();
+    /**
+     * Virtual Destructor
+     */
+    virtual ~CAutoHideSideBar();
 
-	/**
-	 * Removes the given DockWidgetSideTab from the tabbar
-	 */
-	void removeTab(CAutoHideTab* SideTab);
+    /**
+     * Removes the given DockWidgetSideTab from the tabbar
+     */
+    void removeTab(CAutoHideTab *SideTab);
 
-	/**
-	 * Insert dock widget into the side bar.
-	 * The function creates the auto hide dock container, inserts the
-	 * auto hide tab
-	 */
-	CAutoHideDockContainer* insertDockWidget(int Index, CDockWidget* DockWidget);
+    /**
+     * Insert dock widget into the side bar.
+     * The function creates the auto hide dock container, inserts the
+     * auto hide tab
+     */
+    CAutoHideDockContainer *insertDockWidget(int Index, CDockWidget *DockWidget);
 
-	/**
-	 * Removes the auto hide widget from this side bar
-	 */
-	void removeAutoHideWidget(CAutoHideDockContainer* AutoHideWidget);
+    /**
+     * Removes the auto hide widget from this side bar
+     */
+    void removeAutoHideWidget(CAutoHideDockContainer *AutoHideWidget);
 
-	/**
-	 * Adds the given AutoHideWidget to this sidebar.
-	 * If the AutoHideWidget is in another sidebar, then it will be removed
-	 * from this sidebar.
-	 */
-	void addAutoHideWidget(CAutoHideDockContainer* AutoHideWidget);
+    /**
+     * Adds the given AutoHideWidget to this sidebar.
+     * If the AutoHideWidget is in another sidebar, then it will be removed
+     * from this sidebar.
+     */
+    void addAutoHideWidget(CAutoHideDockContainer *AutoHideWidget);
 
-	/**
-	 * Returns orientation of side tab.
-	 */
-	Qt::Orientation orientation() const;
+    /**
+     * Returns orientation of side tab.
+     */
+    Qt::Orientation orientation() const;
 
-	/*
-	 * get the side tab widget at position, returns nullptr if it's out of bounds
-	 */
-	CAutoHideTab* tabAt(int index) const;
+    /*
+        * get the side tab widget at position, returns nullptr if it's out of bounds
+        */
+    CAutoHideTab *tabAt(int index) const;
 
-	/*
-	 * Gets the count of the tab widgets
-	 */
-	int tabCount() const;
+    /*
+        * Gets the count of the tab widgets
+        */
+    int tabCount() const;
 
-	/**
-	 * Getter for side tab bar area property
-	 */
-	SideBarLocation sideBarLocation() const;
+    /**
+     * Getter for side tab bar area property
+     */
+    SideBarLocation sideBarLocation() const;
 
-	/**
-	 * Overrides the minimumSizeHint() function of QScrollArea
-	 * The minimumSizeHint() is bigger than the sizeHint () for the scroll
-	 * area because even if the scrollbars are invisible, the required speace
-	 * is reserved in the minimumSizeHint(). This override simply returns
-	 * sizeHint();
-	 */
-	virtual QSize minimumSizeHint() const override;
+    /**
+     * Overrides the minimumSizeHint() function of QScrollArea
+     * The minimumSizeHint() is bigger than the sizeHint () for the scroll
+     * area because even if the scrollbars are invisible, the required speace
+     * is reserved in the minimumSizeHint(). This override simply returns
+     * sizeHint();
+     */
+    virtual QSize minimumSizeHint() const override;
 
-	/**
-	 * The function provides a sizeHint that matches the height of the
-	 * internal viewport.
-	 */
-	virtual QSize sizeHint() const override;
+    /**
+     * The function provides a sizeHint that matches the height of the
+     * internal viewport.
+     */
+    virtual QSize sizeHint() const override;
 
-	/**
-	 * Getter for spacing property - returns the spacing of the tabs
-	 */
-	int spacing() const;
+    /**
+     * Getter for spacing property - returns the spacing of the tabs
+     */
+    int spacing() const;
 
-	/**
-	 * Setter for spacing property - sets the spacing
-	 */
-	void setSpacing(int Spacing);
+    /**
+     * Setter for spacing property - sets the spacing
+     */
+    void setSpacing(int Spacing);
 
-	/**
-	 * Returns the dock container that hosts this sideBar()
-	 */
-	CDockContainerWidget* dockContainer() const;
+    /**
+     * Returns the dock container that hosts this sideBar()
+     */
+    CDockContainerWidget *dockContainer() const;
 
-  /**
-   * Returns the tab with the given index
-   */
-  CAutoHideTab* tab(int Index) const;
+    /**
+     * Returns the tab with the given index
+     */
+    CAutoHideTab *tab(int Index) const;
 };
 } // namespace ads
 //-----------------------------------------------------------------------------

--- a/src/AutoHideSideBar.h
+++ b/src/AutoHideSideBar.h
@@ -68,6 +68,10 @@ private:
 	friend DockContainerWidgetPrivate;
 	friend CDockContainerWidget;
 
+private Q_SLOTS:
+    void onAutoHideTabMoved(const QPoint& GlobalPos);
+    void onAutoHideTabMoving(const QPoint& GlobalPos);
+
 protected:
 	virtual bool eventFilter(QObject *watched, QEvent *event) override;
 
@@ -168,6 +172,11 @@ public:
 	 * Returns the dock container that hosts this sideBar()
 	 */
 	CDockContainerWidget* dockContainer() const;
+
+  /**
+   * Returns the tab with the given index
+   */
+  CAutoHideTab* tab(int Index) const;
 };
 } // namespace ads
 //-----------------------------------------------------------------------------

--- a/src/AutoHideTab.cpp
+++ b/src/AutoHideTab.cpp
@@ -16,7 +16,6 @@
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-
 //============================================================================
 /// \file   AutoHideTab.cpp
 /// \author Syarif Fakhri
@@ -46,9 +45,9 @@ namespace ads
  */
 struct AutoHideTabPrivate
 {
-    CAutoHideTab* _this;
-    CDockWidget* DockWidget = nullptr;
-    CAutoHideSideBar* SideBar = nullptr;
+    CAutoHideTab *_this;
+    CDockWidget *DockWidget = nullptr;
+    CAutoHideSideBar *SideBar = nullptr;
     Qt::Orientation Orientation{Qt::Vertical};
     QElapsedTimer TimeSinceHoverMousePress;
     QPoint GlobalDragStartMousePosition;
@@ -56,276 +55,258 @@ struct AutoHideTabPrivate
     QPoint TabDragStartPosition;
     eDragState DragState = DraggingInactive;
 
-	/**
-	 * Private data constructor
-	 */
-	AutoHideTabPrivate(CAutoHideTab* _public);
+    /**
+     * Private data constructor
+     */
+    AutoHideTabPrivate(CAutoHideTab *_public);
 
-	/**
-	 * Update the orientation, visibility and spacing based on the area of
-	 * the side bar
-	 */
-	void updateOrientation();
+    /**
+     * Update the orientation, visibility and spacing based on the area of
+     * the side bar
+     */
+    void updateOrientation();
 
-	/**
-	 * Convenience function to ease dock container access
-	 */
-	CDockContainerWidget* dockContainer() const
-	{
-		return DockWidget ? DockWidget->dockContainer() : nullptr;
-	}
+    /**
+     * Convenience function to ease dock container access
+     */
+    CDockContainerWidget *dockContainer() const
+    {
+        return DockWidget ? DockWidget->dockContainer() : nullptr;
+    }
 
-	/**
-	 * Forward this event to the dock container
-	 */
-	void forwardEventToDockContainer(QEvent* event)
-	{
-		auto DockContainer = dockContainer();
-		if (DockContainer)
-		{
-			DockContainer->handleAutoHideWidgetEvent(event, _this);
-		}
-	}
+    /**
+     * Forward this event to the dock container
+     */
+    void forwardEventToDockContainer(QEvent *event)
+    {
+        auto DockContainer = dockContainer();
+        if (DockContainer)
+        {
+            DockContainer->handleAutoHideWidgetEvent(event, _this);
+        }
+    }
 
-	/**
-	 * Saves the drag start position in global and local coordinates
-	 */
-	void saveDragStartMousePosition(const QPoint& GlobalPos)
-	{
-		GlobalDragStartMousePosition = GlobalPos;
-		DragStartMousePosition = _this->mapFromGlobal(GlobalPos);
-	}
+    /**
+     * Saves the drag start position in global and local coordinates
+     */
+    void saveDragStartMousePosition(const QPoint &GlobalPos)
+    {
+        GlobalDragStartMousePosition = GlobalPos;
+        DragStartMousePosition = _this->mapFromGlobal(GlobalPos);
+    }
 
-	/**
-	 * Test function for current drag state
-	 */
-	bool isDraggingState(eDragState dragState) const
-	{
-		return this->DragState == dragState;
-	}
+    /**
+     * Test function for current drag state
+     */
+    bool isDraggingState(eDragState dragState) const
+    {
+        return this->DragState == dragState;
+    }
 
-	/**
-	 * Moves the tab depending on the position in the given mouse event
-	 */
-	void moveTab(QMouseEvent* ev);
+    /**
+     * Moves the tab depending on the position in the given mouse event
+     */
+    void moveTab(QMouseEvent *ev);
 }; // struct DockWidgetTabPrivate
 
-
 //============================================================================
-AutoHideTabPrivate::AutoHideTabPrivate(CAutoHideTab* _public) :
-	_this(_public)
+AutoHideTabPrivate::AutoHideTabPrivate(CAutoHideTab *_public) : _this(_public)
 {
-
 }
-
 
 //============================================================================
 void AutoHideTabPrivate::updateOrientation()
 {
-	bool IconOnly = CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideSideBarsIconOnly);
-	if (IconOnly && !_this->icon().isNull())
-	{
-		_this->setText("");
-		_this->setOrientation(Qt::Horizontal);
-	}
-	else
-	{
-		auto area = SideBar->sideBarLocation();
-		_this->setOrientation((area == SideBarBottom || area == SideBarTop) ? Qt::Horizontal : Qt::Vertical);
-	}
+    bool IconOnly = CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideSideBarsIconOnly);
+    if (IconOnly && !_this->icon().isNull())
+    {
+        _this->setText("");
+        _this->setOrientation(Qt::Horizontal);
+    }
+    else
+    {
+        auto area = SideBar->sideBarLocation();
+        _this->setOrientation((area == SideBarBottom || area == SideBarTop) ? Qt::Horizontal : Qt::Vertical);
+    }
 }
 
-
 //============================================================================
-void AutoHideTabPrivate::moveTab(QMouseEvent* ev)
+void AutoHideTabPrivate::moveTab(QMouseEvent *ev)
 {
     ev->accept();
     QPoint Distance = internal::globalPositionOf(ev) - GlobalDragStartMousePosition;
-	Orientation == Qt::Horizontal ? Distance.setY(0) : Distance.setX(0);
+    Orientation == Qt::Horizontal ? Distance.setY(0) : Distance.setX(0);
     auto TargetPos = Distance + TabDragStartPosition;
 
-	if (Orientation == Qt::Horizontal)
-	{
+    if (Orientation == Qt::Horizontal)
+    {
         TargetPos.rx() = qMax(TargetPos.x(), 0);
         TargetPos.rx() = qMin(_this->parentWidget()->rect().right() - _this->width() + 1, TargetPos.rx());
-	}
-	else
-	{
+    }
+    else
+    {
         TargetPos.ry() = qMax(0, TargetPos.y());
         TargetPos.ry() = qMin(_this->parentWidget()->rect().bottom() - _this->height() + 1, TargetPos.ry());
-	}
+    }
 
     _this->move(TargetPos);
     _this->raise();
 }
 
-
 //============================================================================
-void CAutoHideTab::setSideBar(CAutoHideSideBar* SideTabBar)
+void CAutoHideTab::setSideBar(CAutoHideSideBar *SideTabBar)
 {
-	d->SideBar = SideTabBar;
-	if (d->SideBar)
-	{
-		d->updateOrientation();
-	}
+    d->SideBar = SideTabBar;
+    if (d->SideBar)
+    {
+        d->updateOrientation();
+    }
 }
 
-
 //============================================================================
-CAutoHideSideBar* CAutoHideTab::sideBar() const
+CAutoHideSideBar *CAutoHideTab::sideBar() const
 {
-	return d->SideBar;
+    return d->SideBar;
 }
-
 
 //============================================================================
 void CAutoHideTab::removeFromSideBar()
 {
-	if (d->SideBar == nullptr)
-	{
-		return;
-	}
-	disconnect(d->SideBar);
-	d->SideBar->removeTab(this);
-	setSideBar(nullptr);
+    if (d->SideBar == nullptr)
+    {
+        return;
+    }
+    disconnect(d->SideBar);
+    d->SideBar->removeTab(this);
+    setSideBar(nullptr);
 }
 
 //============================================================================
-CAutoHideTab::CAutoHideTab(QWidget* parent) :
-	CPushButton(parent),
-	d(new AutoHideTabPrivate(this))
+CAutoHideTab::CAutoHideTab(QWidget *parent) : CPushButton(parent),
+                                                d(new AutoHideTabPrivate(this))
 {
-	setAttribute(Qt::WA_NoMousePropagation);
-	setFocusPolicy(Qt::NoFocus);
+    setAttribute(Qt::WA_NoMousePropagation);
+    setFocusPolicy(Qt::NoFocus);
 }
-
 
 //============================================================================
 CAutoHideTab::~CAutoHideTab()
 {
-	ADS_PRINT("~CDockWidgetSideTab()");
-	delete d;
+    ADS_PRINT("~CDockWidgetSideTab()");
+    delete d;
 }
-
 
 //============================================================================
 void CAutoHideTab::updateStyle()
 {
     internal::repolishStyle(this, internal::RepolishDirectChildren);
-	update();
+    update();
 }
-
 
 //============================================================================
 SideBarLocation CAutoHideTab::sideBarLocation() const
 {
     if (d->SideBar)
-	{
+    {
         return d->SideBar->sideBarLocation();
-	}
+    }
 
-	return SideBarLeft;
+    return SideBarLeft;
 }
-
 
 //============================================================================
 void CAutoHideTab::setOrientation(Qt::Orientation Orientation)
 {
-	d->Orientation = Orientation;
-	if (orientation() == Qt::Horizontal)
-	{
-		setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
-	}
-	else
-	{
-		setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
-	}
-	CPushButton::setButtonOrientation((Qt::Horizontal == Orientation)
-		? CPushButton::Horizontal : CPushButton::VerticalTopToBottom);
-	updateStyle();
+    d->Orientation = Orientation;
+    if (orientation() == Qt::Horizontal)
+    {
+        setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    }
+    else
+    {
+        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
+    }
+    CPushButton::setButtonOrientation((Qt::Horizontal == Orientation)
+                                            ? CPushButton::Horizontal
+                                            : CPushButton::VerticalTopToBottom);
+    updateStyle();
 }
-
 
 //============================================================================
 Qt::Orientation CAutoHideTab::orientation() const
 {
-	return d->Orientation;
+    return d->Orientation;
 }
-
 
 //============================================================================
 bool CAutoHideTab::isActiveTab() const
 {
-	if (d->DockWidget && d->DockWidget->autoHideDockContainer())
-	{
-		return d->DockWidget->autoHideDockContainer()->isVisible();
-	}
+    if (d->DockWidget && d->DockWidget->autoHideDockContainer())
+    {
+        return d->DockWidget->autoHideDockContainer()->isVisible();
+    }
 
-	return false;
+    return false;
 }
 
-
 //============================================================================
-CDockWidget* CAutoHideTab::dockWidget() const
+CDockWidget *CAutoHideTab::dockWidget() const
 {
-	return d->DockWidget;
+    return d->DockWidget;
 }
 
-
 //============================================================================
-void CAutoHideTab::setDockWidget(CDockWidget* DockWidget)
+void CAutoHideTab::setDockWidget(CDockWidget *DockWidget)
 {
-	if (!DockWidget)
-	{
-		return;
-	}
-	d->DockWidget = DockWidget;
-	setText(DockWidget->windowTitle());
-	setIcon(d->DockWidget->icon());
-	setToolTip(DockWidget->windowTitle());
+    if (!DockWidget)
+    {
+        return;
+    }
+    d->DockWidget = DockWidget;
+    setText(DockWidget->windowTitle());
+    setIcon(d->DockWidget->icon());
+    setToolTip(DockWidget->windowTitle());
 }
 
-
 //============================================================================
-bool CAutoHideTab::event(QEvent* event)
+bool CAutoHideTab::event(QEvent *event)
 {
-	if (!CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideShowOnMouseOver))
-	{
-		return Super::event(event);
-	}
+    if (!CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideShowOnMouseOver))
+    {
+        return Super::event(event);
+    }
 
-	switch (event->type())
-	{
-	case QEvent::Enter:
-	case QEvent::Leave:
-		 d->forwardEventToDockContainer(event);
-		 break;
+    switch (event->type())
+    {
+    case QEvent::Enter:
+    case QEvent::Leave:
+        d->forwardEventToDockContainer(event);
+        break;
 
-	case QEvent::MouseButtonRelease:
-		 // If AutoHideShowOnMouseOver is active, then the showing is triggered
-		 // by a MousePresRelease sent to this tab. To prevent accidental hiding
-		 // of the tab by a mouse click, we wait at least 500 ms before we accept
-		 // the mouse click
-		 if (!event->spontaneous())
-		 {
-			 d->TimeSinceHoverMousePress.restart();
-			 d->forwardEventToDockContainer(event);
-		 }
-		 else if (d->TimeSinceHoverMousePress.hasExpired(500))
-		 {
-			 d->forwardEventToDockContainer(event);
-		 }
-		 break;
+    case QEvent::MouseButtonRelease:
+        // If AutoHideShowOnMouseOver is active, then the showing is triggered
+        // by a MousePresRelease sent to this tab. To prevent accidental hiding
+        // of the tab by a mouse click, we wait at least 500 ms before we accept
+        // the mouse click
+        if (!event->spontaneous())
+        {
+            d->TimeSinceHoverMousePress.restart();
+            d->forwardEventToDockContainer(event);
+        }
+        else if (d->TimeSinceHoverMousePress.hasExpired(500))
+        {
+            d->forwardEventToDockContainer(event);
+        }
+        break;
 
-	default:
-		break;
-	}
-	return Super::event(event);
+    default:
+        break;
+    }
+    return Super::event(event);
 }
 
-
 //============================================================================
-void CAutoHideTab::mousePressEvent(QMouseEvent* ev)
+void CAutoHideTab::mousePressEvent(QMouseEvent *ev)
 {
     if (ev->button() == Qt::LeftButton)
     {
@@ -338,75 +319,73 @@ void CAutoHideTab::mousePressEvent(QMouseEvent* ev)
     Super::mousePressEvent(ev);
 }
 
-
 //============================================================================
-void CAutoHideTab::mouseMoveEvent(QMouseEvent* ev)
+void CAutoHideTab::mouseMoveEvent(QMouseEvent *ev)
 {
-	if (!(ev->buttons() & Qt::LeftButton) || d->isDraggingState(DraggingInactive))
-	{
-		d->DragState = DraggingInactive;
-		Super::mouseMoveEvent(ev);
-		return;
-	}
+    if (!(ev->buttons() & Qt::LeftButton) || d->isDraggingState(DraggingInactive))
+    {
+        d->DragState = DraggingInactive;
+        Super::mouseMoveEvent(ev);
+        return;
+    }
 
-	// move tab
-	if (d->isDraggingState(DraggingTab))
-	{
-		// Moving the tab is always allowed because it does not mean moving the
-		// dock widget around
-		d->moveTab(ev);
-		Q_EMIT moving(internal::globalPositionOf(ev));
-	}
+    // move tab
+    if (d->isDraggingState(DraggingTab))
+    {
+        // Moving the tab is always allowed because it does not mean moving the
+        // dock widget around
+        d->moveTab(ev);
+        Q_EMIT moving(internal::globalPositionOf(ev));
+    }
 
-	else if (
-		(internal::globalPositionOf(ev) - d->GlobalDragStartMousePosition).manhattanLength() >= QApplication::startDragDistance()) // Wait a few pixels before start moving 
-	{
-		// If we start dragging the tab, we save its inital position to
-		// restore it later
-		if (DraggingTab != d->DragState)
-		{
-			d->TabDragStartPosition = this->pos();
-		}
-		d->DragState = DraggingTab;
-		return;
+    else if (
+        (internal::globalPositionOf(ev) - d->GlobalDragStartMousePosition).manhattanLength() >= QApplication::startDragDistance()) // Wait a few pixels before start moving
+    {
+        // If we start dragging the tab, we save its inital position to
+        // restore it later
+        if (DraggingTab != d->DragState)
+        {
+            d->TabDragStartPosition = this->pos();
+        }
+        d->DragState = DraggingTab;
+        return;
     }
 
     Super::mouseMoveEvent(ev);
 }
 
-
 //============================================================================
-void CAutoHideTab::mouseReleaseEvent(QMouseEvent* ev)
+void CAutoHideTab::mouseReleaseEvent(QMouseEvent *ev)
 {
-	if (ev->button() == Qt::LeftButton)
-	{
-		auto CurrentDragState = d->DragState;
-		d->GlobalDragStartMousePosition = QPoint();
-		d->DragStartMousePosition = QPoint();
-		d->DragState = DraggingInactive;
+    if (ev->button() == Qt::LeftButton)
+    {
+        auto CurrentDragState = d->DragState;
+        d->GlobalDragStartMousePosition = QPoint();
+        d->DragStartMousePosition = QPoint();
+        d->DragState = DraggingInactive;
 
-		switch (CurrentDragState)
-		{
-		case DraggingInactive:
-		case DraggingMousePressed:
-			Q_EMIT released();
-			break;
-		case DraggingTab:
-			// End of tab moving, emit signal
-			ev->accept();
-			Q_EMIT moved(internal::globalPositionOf(ev));
-			break;
-		default:; // do nothing
-		}
-	} 
+        switch (CurrentDragState)
+        {
+        case DraggingInactive:
+        case DraggingMousePressed:
+            Q_EMIT released();
+            break;
+        case DraggingTab:
+            // End of tab moving, emit signal
+            ev->accept();
+            Q_EMIT moved(internal::globalPositionOf(ev));
+            break;
+        default:; // do nothing
+        }
+    }
 
-	Super::mouseReleaseEvent(ev);
+    Super::mouseReleaseEvent(ev);
 }
 
 //============================================================================
 bool CAutoHideTab::iconOnly() const
 {
-	return CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideSideBarsIconOnly) && !icon().isNull();
+    return CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideSideBarsIconOnly) && !icon().isNull();
 }
 
 }

--- a/src/AutoHideTab.h
+++ b/src/AutoHideTab.h
@@ -18,7 +18,6 @@
 ** License along with this library; If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-
 //============================================================================
 /// \file   AutoHideTab.h
 /// \author Syarif Fakhri
@@ -55,8 +54,8 @@ class ADS_EXPORT CAutoHideTab : public CPushButton
     Q_PROPERTY(bool activeTab READ isActiveTab)
     Q_PROPERTY(bool iconOnly READ iconOnly)
 
-private:    
-    AutoHideTabPrivate* d; ///< private data (pimpl)
+private:
+    AutoHideTabPrivate *d; ///< private data (pimpl)
     friend struct AutoHideTabPrivate;
     friend class CDockWidget;
     friend class CAutoHideDockContainer;
@@ -68,81 +67,80 @@ private:
 protected:
     void setSideBar(CAutoHideSideBar *SideTabBar);
     void removeFromSideBar();
-    bool event(QEvent* event) override;
-    void mousePressEvent(QMouseEvent* ev) override;
-    void mouseReleaseEvent(QMouseEvent* ev) override;
-    void mouseMoveEvent(QMouseEvent* ev) override;
-
+    bool event(QEvent *event) override;
+    void mousePressEvent(QMouseEvent *ev) override;
+    void mouseReleaseEvent(QMouseEvent *ev) override;
+    void mouseMoveEvent(QMouseEvent *ev) override;
 
 public:
     using Super = CPushButton;
 
-	/**
-	 * Default Constructor
-	 * param[in] DockWidget The dock widget this title bar belongs to
-	 * param[in] parent The parent widget of this title bar
-	 */
-	CAutoHideTab(QWidget* parent = nullptr);
+    /**
+     * Default Constructor
+     * param[in] DockWidget The dock widget this title bar belongs to
+     * param[in] parent The parent widget of this title bar
+     */
+    CAutoHideTab(QWidget *parent = nullptr);
 
-	/**
-	 * Virtual Destructor
-	 */
-	virtual ~CAutoHideTab();
+    /**
+     * Virtual Destructor
+     */
+    virtual ~CAutoHideTab();
 
-	/**
-	 * Update stylesheet style if a property changes
-	 */
-	void updateStyle();
+    /**
+     * Update stylesheet style if a property changes
+     */
+    void updateStyle();
 
-	/**
-	 * Getter for side tab bar area property
-	 */
-	SideBarLocation sideBarLocation() const;
+    /**
+     * Getter for side tab bar area property
+     */
+    SideBarLocation sideBarLocation() const;
 
-	/**
-	 * Set orientation vertical or horizontal
-	 */
-	void setOrientation(Qt::Orientation Orientation);
+    /**
+     * Set orientation vertical or horizontal
+     */
+    void setOrientation(Qt::Orientation Orientation);
 
-	/**
-	 * Returns the current orientation
-	 */
-	Qt::Orientation orientation() const;
+    /**
+     * Returns the current orientation
+     */
+    Qt::Orientation orientation() const;
 
-	/**
-	 * Returns true, if this is the active tab. The tab is active if the auto
-	 * hide widget is visible
-	 */
-	bool isActiveTab() const;
+    /**
+     * Returns true, if this is the active tab. The tab is active if the auto
+     * hide widget is visible
+     */
+    bool isActiveTab() const;
 
-	/**
-	 * returns the dock widget this belongs to
-	 */
-	CDockWidget* dockWidget() const;
+    /**
+     * returns the dock widget this belongs to
+     */
+    CDockWidget *dockWidget() const;
 
-	/**
-	 * Sets the dock widget that is controlled by this tab
-	 */
-	void setDockWidget(CDockWidget* DockWidget);
+    /**
+     * Sets the dock widget that is controlled by this tab
+     */
+    void setDockWidget(CDockWidget *DockWidget);
 
-	/**
-	 * Returns true if the auto hide config flag AutoHideSideBarsIconOnly
-	 * is set and if the tab has an icon - that means the icon is not null
-	 */
-	bool iconOnly() const;
+    /**
+     * Returns true if the auto hide config flag AutoHideSideBarsIconOnly
+     * is set and if the tab has an icon - that means the icon is not null
+     */
+    bool iconOnly() const;
 
-	/**
-	 * Returns the side bar that contains this tab or a nullptr if the tab is
-	 * not in a side bar
-	 */
-	CAutoHideSideBar* sideBar() const;
+    /**
+     * Returns the side bar that contains this tab or a nullptr if the tab is
+     * not in a side bar
+     */
+    CAutoHideSideBar *sideBar() const;
 
 Q_SIGNALS:
-	void moved(const QPoint& GlobalPos);
-	void moving(const QPoint& GlobalPos);
+    void moved(const QPoint &GlobalPos);
+    void moving(const QPoint &GlobalPos);
 }; // class AutoHideTab
 }
- // namespace ads
+// namespace ads
 //-----------------------------------------------------------------------------
 
 #endif

--- a/src/AutoHideTab.h
+++ b/src/AutoHideTab.h
@@ -52,24 +52,27 @@ class ADS_EXPORT CAutoHideTab : public CPushButton
 
     Q_PROPERTY(int sideBarLocation READ sideBarLocation)
     Q_PROPERTY(Qt::Orientation orientation READ orientation)
-	Q_PROPERTY(bool activeTab READ isActiveTab)
-	Q_PROPERTY(bool iconOnly READ iconOnly)
+    Q_PROPERTY(bool activeTab READ isActiveTab)
+    Q_PROPERTY(bool iconOnly READ iconOnly)
 
 private:    
-	AutoHideTabPrivate* d; ///< private data (pimpl)
+    AutoHideTabPrivate* d; ///< private data (pimpl)
     friend struct AutoHideTabPrivate;
-	friend class CDockWidget;
-	friend class CAutoHideDockContainer;
-	friend class CAutoHideSideBar;
-	friend class CDockAreaWidget;
-	friend class CDockContainerWidget;
-	friend DockContainerWidgetPrivate;
-
+    friend class CDockWidget;
+    friend class CAutoHideDockContainer;
+    friend class CAutoHideSideBar;
+    friend class CDockAreaWidget;
+    friend class CDockContainerWidget;
+    friend DockContainerWidgetPrivate;
 
 protected:
-	void setSideBar(CAutoHideSideBar *SideTabBar);
-	void removeFromSideBar();
-	virtual bool event(QEvent* event) override;
+    void setSideBar(CAutoHideSideBar *SideTabBar);
+    void removeFromSideBar();
+    bool event(QEvent* event) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+
 
 public:
     using Super = CPushButton;
@@ -133,6 +136,10 @@ public:
 	 * not in a side bar
 	 */
 	CAutoHideSideBar* sideBar() const;
+
+Q_SIGNALS:
+	void moved(const QPoint& GlobalPos);
+	void moving(const QPoint& GlobalPos);
 }; // class AutoHideTab
 }
  // namespace ads

--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -382,7 +382,7 @@ DockContainerWidgetPrivate::DockContainerWidgetPrivate(CDockContainerWidget* _pu
 	DelayedAutoHideTimer.setInterval(500);
 	QObject::connect(&DelayedAutoHideTimer, &QTimer::timeout, [this](){
 		auto GlobalPos = DelayedAutoHideTab->mapToGlobal(QPoint(0, 0));
-		qApp->sendEvent(DelayedAutoHideTab, new QMouseEvent(QEvent::MouseButtonPress,
+		qApp->sendEvent(DelayedAutoHideTab, new QMouseEvent(QEvent::MouseButtonRelease,
 				QPoint(0, 0), GlobalPos, Qt::LeftButton, {Qt::LeftButton}, Qt::NoModifier));
 	});
 }
@@ -2118,7 +2118,7 @@ void CDockContainerWidget::handleAutoHideWidgetEvent(QEvent* e, QWidget* w)
 			 }
 			 break;
 
-		case QEvent::MouseButtonPress:
+		case QEvent::MouseButtonRelease:
 			 d->DelayedAutoHideTimer.stop();
 			 break;
 


### PR DESCRIPTION
![rearrange_tabs](https://user-images.githubusercontent.com/4475295/219923315-46f8af1a-20f5-4154-8335-e42ab769700c.gif)

Hi @githubuser0xFFFF , hope you are doing well :). This is a tiny QOL feature to allow rearranging of auto hide tabs via dragging.

All of the functional changes are in [Add draggable auto hide tab functionality](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/commit/a48108e4493f62b454bcd7619652c97dc5e8d2a1) and [fix flicker](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/commit/e949dcd9b69a15b22bf01a96c0ecefbf1fbc48e8), the rest of the commits are only formatting or merge changes. 

Some details:

1. The implementation of the dragging is similar to the DockWidgetTab implementation, however I added live update while dragging, so it reacts on mouse move, and finalizes the movement on mouse release instead. I believe this is more intuitive for the user and gives a nice live update while dragging.
2. I changed the open from mouse press to mouse release, so that a user can drag without opening the auto hide tab.

Please test and let me know if there any changes you'd like me to make, thanks!