### PR TITLE
Change targets name based on Qt version

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::Co
 if(WIN32 AND QT_VERSION_MAJOR LESS 6)
     target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::AxContainer)
 endif()
-target_link_libraries(AdvancedDockingSystemDemo PRIVATE qtadvanceddocking)
+target_link_libraries(AdvancedDockingSystemDemo PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
 set_target_properties(AdvancedDockingSystemDemo PROPERTIES 
     AUTOMOC ON
     AUTORCC ON

--- a/examples/autohide/CMakeLists.txt
+++ b/examples/autohide/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(AutoHideExample WIN32
     mainwindow.ui
 )
 target_include_directories(AutoHideExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(AutoHideExample PRIVATE qtadvanceddocking)
+target_link_libraries(AutoHideExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
 target_link_libraries(AutoHideExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/centralwidget/CMakeLists.txt
+++ b/examples/centralwidget/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(CentralWidgetExample WIN32
     mainwindow.ui
 )
 target_include_directories(CentralWidgetExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(CentralWidgetExample PRIVATE qtadvanceddocking)
+target_link_libraries(CentralWidgetExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
 target_link_libraries(CentralWidgetExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/deleteonclose/CMakeLists.txt
+++ b/examples/deleteonclose/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(DeleteOnCloseTest WIN32
     main.cpp
 )
 target_include_directories(DeleteOnCloseTest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(DeleteOnCloseTest PRIVATE qtadvanceddocking)
+target_link_libraries(DeleteOnCloseTest PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
 target_link_libraries(DeleteOnCloseTest PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/dockindock/CMakeLists.txt
+++ b/examples/dockindock/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(DockInDockExample WIN32
     mainframe.cpp
 )
 target_include_directories(DockInDockExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(DockInDockExample PRIVATE qtadvanceddocking)
+target_link_libraries(DockInDockExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
 target_link_libraries(DockInDockExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                            Qt${QT_VERSION_MAJOR}::Gui 
                                            Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/emptydockarea/CMakeLists.txt
+++ b/examples/emptydockarea/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(EmptyDockAreaExample WIN32
     mainwindow.ui
 )
 target_include_directories(EmptyDockAreaExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(EmptyDockAreaExample PRIVATE qtadvanceddocking)
+target_link_libraries(EmptyDockAreaExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
 target_link_libraries(EmptyDockAreaExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/hideshow/CMakeLists.txt
+++ b/examples/hideshow/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(HideShowExample WIN32
     MainWindow.ui
 )
 target_include_directories(HideShowExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(HideShowExample PRIVATE qtadvanceddocking)
+target_link_libraries(HideShowExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
 target_link_libraries(HideShowExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                              Qt${QT_VERSION_MAJOR}::Gui 
                                              Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/sidebar/CMakeLists.txt
+++ b/examples/sidebar/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(SidebarExample WIN32
     MainWindow.ui
 )
 target_include_directories(SidebarExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(SidebarExample PRIVATE qtadvanceddocking)
+target_link_libraries(SidebarExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
 target_link_libraries(SidebarExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                             Qt${QT_VERSION_MAJOR}::Gui 
                                             Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(SimpleExample WIN32
     MainWindow.ui
 )
 target_include_directories(SimpleExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(SimpleExample PRIVATE qtadvanceddocking)
+target_link_libraries(SimpleExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
 target_link_libraries(SimpleExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                            Qt${QT_VERSION_MAJOR}::Gui 
                                            Qt${QT_VERSION_MAJOR}::Widgets)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,50 +64,52 @@ if (UNIX AND NOT APPLE)
     set(ads_SRCS linux/FloatingWidgetTitleBar.cpp ${ads_SRCS})
     set(ads_HEADERS linux/FloatingWidgetTitleBar.h ${ads_HEADERS})
 endif()
+
+set(library_name "qt${QT_VERSION_MAJOR}advanceddocking")
 if(BUILD_STATIC)
-    add_library(qtadvanceddocking STATIC ${ads_SRCS} ${ads_HEADERS})
-    target_compile_definitions(qtadvanceddocking PUBLIC ADS_STATIC)
+    add_library(${library_name} STATIC ${ads_SRCS} ${ads_HEADERS})
+    target_compile_definitions( ${library_name} PUBLIC ADS_STATIC)
 else()
-    add_library(qtadvanceddocking SHARED ${ads_SRCS} ${ads_HEADERS})
-    target_compile_definitions(qtadvanceddocking PRIVATE ADS_SHARED_EXPORT)
+    add_library( ${library_name} SHARED ${ads_SRCS} ${ads_HEADERS})
+    target_compile_definitions( ${library_name} PRIVATE ADS_SHARED_EXPORT)
 endif()
 
-add_library(ads::qtadvanceddocking ALIAS qtadvanceddocking)
+add_library(ads::${library_name} ALIAS ${library_name})
 
-target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core 
+target_link_libraries(${library_name} PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)
 if (UNIX AND NOT APPLE)
-  target_link_libraries(qtadvanceddocking PUBLIC xcb)
+  target_link_libraries(${library_name} PUBLIC xcb)
 endif()
-set_target_properties(qtadvanceddocking PROPERTIES
+set_target_properties(${library_name} PROPERTIES
     AUTOMOC ON
     AUTORCC ON
     CXX_EXTENSIONS OFF
     VERSION ${VERSION_SHORT}
-    EXPORT_NAME "qtadvanceddocking"
+    EXPORT_NAME ${library_name}
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
 )
 if(QT_VERSION_MAJOR STREQUAL "5")
-    set_target_properties(qtadvanceddocking PROPERTIES
+    set_target_properties(${library_name} PROPERTIES
         CXX_STANDARD 14
         CXX_STANDARD_REQUIRED ON)
 elseif(QT_VERSION_MAJOR STREQUAL "6")
-    set_target_properties(qtadvanceddocking PROPERTIES
+    set_target_properties(${library_name} PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON)
 endif()
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    "qtadvanceddockingConfigVersion.cmake"
+    "${library_name}ConfigVersion.cmake"
     VERSION ${VERSION_SHORT}
     COMPATIBILITY SameMajorVersion
 )
 install(FILES ${ads_HEADERS}
-    DESTINATION include
+    DESTINATION include/${library_name}
     COMPONENT headers
 )
 install(FILES
@@ -116,7 +118,7 @@ install(FILES
     DESTINATION license/ads
     COMPONENT license
 )
-install(TARGETS qtadvanceddocking
+install(TARGETS ${library_name}
     EXPORT adsTargets
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
@@ -127,13 +129,16 @@ install(TARGETS qtadvanceddocking
 install(EXPORT adsTargets
     FILE adsTargets.cmake
     NAMESPACE ads::
-    DESTINATION lib/cmake/qtadvanceddocking
+    DESTINATION lib/cmake/${library_name}
 )
-install(FILES qtadvanceddockingConfig.cmake "${CMAKE_CURRENT_BINARY_DIR}/qtadvanceddockingConfigVersion.cmake"
-    DESTINATION lib/cmake/qtadvanceddocking
+install(FILES qtadvanceddockingConfig.cmake RENAME ${library_name}Config.cmake
+    DESTINATION lib/cmake/${library_name}
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${library_name}ConfigVersion.cmake"
+    DESTINATION lib/cmake/${library_name}
 )
 
-target_include_directories(qtadvanceddocking PUBLIC
+target_include_directories(${library_name} PUBLIC
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )


### PR DESCRIPTION
This PR is to make Qt-Advanced-Docking-System linked with Qt6 and Qt5 coexists.

I am trying to add Qt-Advanced-Docking-System ad PySide bindings to conda-forge : https://github.com/conda-forge/staged-recipes/pull/22004
The PyQt bindings is already [there](https://github.com/conda-forge/pyqtads-feedstock) but ads is built statically and only with Qt5 version.
So, I would like to make a separate package for ads that can be a dependency of both PyQt and PySide bindings, with bindings for Qt6 and Qt5. We would end with 5 packages: `qt-advanced-docking-system`, `pyqtads` (for Qt5), `pyqt6ads` (for Qt6), `pyside2qtads` (for Qt5) and `pyside6qtads` (for Qt6).

Regards
