### PR TITLE
Fix wrong include path in CMake install

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,7 @@ install(TARGETS ${library_name}
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
-    INCLUDES DESTINATION include
+    INCLUDES DESTINATION include/${library_name}
 )
 
 install(EXPORT adsTargets


### PR DESCRIPTION
Fix wrong include path in CMake install introcuded in #489 