### PR TITLE
Improve central widget resize behaviour

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -1374,9 +1374,12 @@ CDockAreaTitleBar* CDockAreaWidget::titleBar() const
 //============================================================================
 bool CDockAreaWidget::isCentralWidgetArea() const
 {
-    if (dockWidgetsCount()!= 1)
+    if (!CDockManager::testConfigFlag(CDockManager::AllowMultipleCentralWidgets))
     {
-        return false;
+        if (dockWidgetsCount()!= 1)
+        {
+            return false;
+        }
     }
 
     return dockManager()->centralWidget() == dockWidgets().constFirst();

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -203,6 +203,7 @@ public:
 														 //!< If neither this nor FloatingContainerForceNativeTitleBar is set (the default) native titlebars are used except on known bad systems.
 														 //! Users can overwrite this by setting the environment variable ADS_UseNativeTitle to "1" or "0".
 		MiddleMouseButtonClosesTab = 0x2000000, //! If the flag is set, the user can use the mouse middle button to close the tab under the mouse
+		AllowMultipleCentralWidgets = 0x4000000, //! If the flag is set, central widget resize behaviour is enabled even when there is more than one widget docked in the central area.
 
         DefaultDockAreaButtons = DockAreaHasCloseButton
 							   | DockAreaHasUndockButton


### PR DESCRIPTION
When using the central widget functionality, only the central widget is resized when the window is resized. However this behaviour only happens when there is a single widget in the central area.

This patch adds a new config flag called AllowMultipleCentralWidgets which allows this resize behaviour to also take effect when there is more than one widget docked in the central area.

This was useful in my project, so maybe other people will want this too.
(one thing I'm not sure about is the naming of "AllowMultipleCentralWidgets")