### PR TITLE
Add config to make close button collapse auto hide dock

### DIFF
--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -415,7 +415,12 @@ void CDockAreaTitleBar::onTabsMenuAboutToShow()
 void CDockAreaTitleBar::onCloseButtonClicked()
 {
     ADS_PRINT("CDockAreaTitleBar::onCloseButtonClicked");
-	if (d->testConfigFlag(CDockManager::DockAreaCloseButtonClosesTab))
+	if (CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideCloseButtonCollapsesDock) &&
+		d->DockArea->autoHideDockContainer())
+	{
+		d->DockArea->autoHideDockContainer()->collapseView(true);
+	}
+	else if (d->testConfigFlag(CDockManager::DockAreaCloseButtonClosesTab))
 	{
 		d->TabBar->closeTab(d->TabBar->currentIndex());
 	}

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -239,6 +239,7 @@ public:
 		AutoHideButtonCheckable = 0x08, //!< If the flag is set, the auto hide button will be checked and unchecked depending on the auto hide state. Mainly for styling purposes.
 		AutoHideSideBarsIconOnly = 0x10,///< show only icons in auto hide side tab - if a tab has no icon, then the text will be shown
 		AutoHideShowOnMouseOver = 0x20, ///< show the auto hide window on mouse over tab and hide it if mouse leaves auto hide container
+		AutoHideCloseButtonCollapsesDock = 0x40, ///< Close button of an auto hide container closes the dock instead of hiding it completely
 
 		DefaultAutoHideConfig = AutoHideFeatureEnabled
 			                  | DockAreaHasAutoHideButton ///< the default configuration for left and right side bars


### PR DESCRIPTION
Hi, @githubuser0xFFFF, hope you are doing well :). This is is a small QOL PR for the auto hide dock. I noticed that some users don't understand the distinction between closing an auto hide dock and collapsing an auto hide dock. This leads to situations where they press the close button (losing the side tab widget) instead of simply clicking outside the auto hide dock (collapsing the dock). 

Therefore, I added a config so that pressing the close button would simply collapse the auto hide dock instead of hiding it. 

Here's the new behavior:
![close_tab_new](https://user-images.githubusercontent.com/4475295/235085250-0686de9e-53f4-4f6a-a66a-41db53c82fd9.gif)


And the old behavior:
![close_tab_old](https://user-images.githubusercontent.com/4475295/235085269-ec13d1a3-9a16-4aa6-b51e-a2d06fbb4a21.gif)

