### PR TITLE
cmake: alias qtadvanceddocking to qt(5|6)advanceddocking for compatability

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,11 +75,13 @@ if(BUILD_STATIC)
     add_library(${library_name} STATIC ${ads_SRCS} ${ads_HEADERS})
     target_compile_definitions( ${library_name} PUBLIC ADS_STATIC)
 else()
-    add_library( ${library_name} SHARED ${ads_SRCS} ${ads_HEADERS})
-    target_compile_definitions( ${library_name} PRIVATE ADS_SHARED_EXPORT)
+    add_library(${library_name} SHARED ${ads_SRCS} ${ads_HEADERS})
+    target_compile_definitions(${library_name} PRIVATE ADS_SHARED_EXPORT)
 endif()
 
 add_library(ads::${library_name} ALIAS ${library_name})
+# alias qtadvanceddocking to qt(5|6)advanceddocking for compatability
+add_library(qtadvanceddocking ALIAS ${library_name})
 
 target_link_libraries(${library_name} PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                Qt${QT_VERSION_MAJOR}::Gui 


### PR DESCRIPTION
alias qtadvanceddocking to qt(5|6)advanceddocking for backwards compatibility.

Current master breaks all cmake projects and would force them to commit to either the qt5 or qt6 target, or use qt{QT_VERSION_MAJOR}advanceddocking to select the qt version automatically.
Since the latter is what should be reasonably expected (i think) an alias would maintain compatibility.
If a specific qt version is desired one can still switch to the specific target.

ref https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/pull/489