### PR TITLE
Sometimes sidebar visibility state is incorrect

### DIFF
--- a/src/AutoHideSideBar.h
+++ b/src/AutoHideSideBar.h
@@ -134,6 +134,11 @@ public:
 	 */
 	int tabCount() const;
 
+	/*
+	 * Gets the count of visible tab widgets
+	 */
+	int visibleTabCount() const;
+
 	/**
 	 * Getter for side tab bar area property
 	 */


### PR DESCRIPTION
Hi @githubuser0xFFFF, hope you are doing well 😄. I have a very interesting bug fix. Currently I can see that `AutoHideSideBarPrivate::handleViewportEvent` and `case QEvent::Resize` is responsible for hiding the sidebar widgets if any of the sidebar widgets are hidden (e.g. during view toggle - disable). Since this depends on the `Size < TabSize`, this can sometimes be incorrect during certain scenarios. 

There are two scenarios this bug comes about. The first scenario is more easily reproducible, while the second one unfortunately I can only reproduce in our application - not in any of the demo applications.

Here's how to reproduce the first scenario:
1. Have a small side tab be the first widget, and a larger side tab to be the second widget. It's easiest to do this if you have one widget have an icon and the other widget without an icon.
2.  Hide the first widget, then the second widget.
3. the sidebar will not be hidden

![side_tab_bug](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/assets/4475295/2a02bbcd-e245-4069-899b-911f7e48556b)

The second scenario occurs only during application startup. During that time, before first shown, it seems the sizes of the tabs and of the sidebar are incorrect (likely because layout calculations have not run yet), causing it to be hidden even when there are side tab widgets.

The fix is simple, instead of using resize to hide widgets, I simply hook on to the auto hide tab widget itself being hidden and hide the side bar if there are no more visible auto hide tabs. Let me know if this covers all the cases, thanks!

