### PR TITLE
Bug fix sidebar state during restore

### DIFF
--- a/src/AutoHideSideBar.cpp
+++ b/src/AutoHideSideBar.cpp
@@ -321,7 +321,7 @@ int CAutoHideSideBar::visibleTabCount() const
 	int count = 0;
 	for (auto i = 0; i < tabCount(); i++)
 	{
-		if (tabAt(i)->isVisible())
+		if (tabAt(i)->isVisibleTo(parentWidget()))
 		{
 			count++;
 		}

--- a/src/AutoHideSideBar.cpp
+++ b/src/AutoHideSideBar.cpp
@@ -279,7 +279,7 @@ bool CAutoHideSideBar::eventFilter(QObject *watched, QEvent *event)
 		 show();
 	     break;
 
-	case QEvent::Hide:
+	case QEvent::HideToParent:
 		 if (!hasVisibleTabs())
 		 {
 			 hide();

--- a/src/AutoHideSideBar.cpp
+++ b/src/AutoHideSideBar.cpp
@@ -336,7 +336,7 @@ bool CAutoHideSideBar::hasVisibleTabs() const
 {
 	for (auto i = 0; i < tabCount(); i++)
 	{
-		if (tabAt(i)->isVisible())
+		if (tabAt(i)->isVisibleTo(parentWidget()))
 		{
 			return true;
 		}

--- a/src/AutoHideSideBar.h
+++ b/src/AutoHideSideBar.h
@@ -135,14 +135,14 @@ public:
 	int tabCount() const;
 
 	/**
-	 * Returns the number of visible tabs
+	 * Returns the number of visible tabs to its parent widget.
 	 */
 	int visibleTabCount() const;
 
 	/**
-	 * Returns true, if the sidebar contains visible tabs.
+	 * Returns true, if the sidebar contains visible tabs to its parent widget.
 	 * The function returns as soon as it finds the first visible tab.
-	 * That means, if you just want to find out if theee are visible tabs
+	 * That means, if you just want to find out if there are visible tabs
 	 * then this function is quicker than visibleTabCount()
 	 */
 	bool hasVisibleTabs() const;


### PR DESCRIPTION
Hi @githubuser0xFFFF. Thanks for merging #524, this is just a small addition to that. During restore, the entire dock manager state is hidden, so `isVisible` does not return the correct state (It thinks all the tabs are hidden in the sidebar, when actually the entire window is just hidden during restore). There's two possible fixes for this, ignore the hideEvent during `restoreState`, or simply check the visibility to the parent. I opted for the latter fix since I can see you are already listening to the `ShowToParent` event.

Thanks!