### PR TITLE
Fix CMake scripts for FreeBSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,12 @@ target_link_libraries(${library_name} PUBLIC Qt${QT_VERSION_MAJOR}::Core
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)
 if (UNIX AND NOT APPLE)
-  target_link_libraries(${library_name} PUBLIC xcb)
+  if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+      find_package(X11 REQUIRED)
+      target_link_libraries(${library_name} PUBLIC X11::xcb)
+  else()
+    target_link_libraries(${library_name} PUBLIC xcb)
+  endif()
 endif()
 set_target_properties(${library_name} PROPERTIES
     AUTOMOC ON


### PR DESCRIPTION
This fixes linking of the XCB library on FreeBSD.

Based on my CMake knowledge I do think that the same technique should be used for other platforms too (the use of `find_package(X11)` together with linking to the corresponding `X11::xcb` target). However, I did not want to modify anything existing to prevent breaking something I'm unaware of.