### PR TITLE
Fix crash in auto hide tab

### DIFF
--- a/src/AutoHideTab.cpp
+++ b/src/AutoHideTab.cpp
@@ -478,7 +478,7 @@ void CAutoHideTab::mouseReleaseEvent(QMouseEvent* ev)
 		case DraggingFloatingWidget:
 			 ev->accept();
 			 d->FloatingWidget->finishDragging();
-			 if (d->DockWidget->isAutoHide() && d->DragStartOrientation != orientation())
+			 if (d->DockWidget->autoHideDockContainer() && d->DragStartOrientation != orientation())
 			 {
 				 d->DockWidget->autoHideDockContainer()->resetToInitialDockWidgetSize();
 			 }


### PR DESCRIPTION
Hi @githubuser0xFFFF, hope you are doing well 😄 

Here's a bug fix for a small crash that I found.

**How to reproduce:**

1. In `AdvancedDockingSystem::MainWindow`, add `CDockManager::setAutoHideConfigFlag(CDockManager::AutoHideSideBarsIconOnly);`
2. Pin a dock that has an icon (Ensure that it's pinned to the left or right side)
3. Try to drag it out into its own window
4. Observe that it crashes on `CAutoHideTab::mouseReleaseEvent` -> `				 d->DockWidget->autoHideDockContainer()->resetToInitialDockWidgetSize();` because autoHideDockContainer is nullptr 

**Fix**
The crash can actually happen with non icon only tabs, but is masked by the orientation check, this is why it doesn't happen normally.
Fix: Check if auto hide container exists first on mouse finish dragging event.