### PR TITLE
Enabled modifying MSVC runtime in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
+if (POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif (POLICY CMP0091)
+
 # By default, the version information is extracted from the git index. However,
 # we can override this behavior by explicitly setting ADS_VERSION and
 # skipping the git checks. This is useful for cases where this project is being


### PR DESCRIPTION
When targeting msvc, in static builds, unable to specify [CMAKE_MSVC_RUNTIME_LIBRARY](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html), because the policy [CMP0091](https://cmake.org/cmake/help/latest/policy/CMP0091.html#policy:CMP0091) is not set. It has to be set to NEW (defaults to OLD), and its default value is already deprecated anyway. This commit is a quick fix for that.