### PR TITLE
Improve Python support and Builds across more Distributions

### DIFF
--- a/demo/status_dialog.py
+++ b/demo/status_dialog.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 from PyQt5 import uic
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
 UI_FILE = os.path.join(os.path.dirname(__file__), 'StatusDialog.ui')
 StatusDialogUI, StatusDialogBase = uic.loadUiType(UI_FILE)

--- a/examples/autohide/main.py
+++ b/examples/autohide/main.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (QApplication, QLabel, QCalendarWidget, QFrame, QTre
                              QTableWidget, QFileSystemModel, QPlainTextEdit, QToolBar,
                              QWidgetAction, QComboBox, QAction, QSizePolicy, QInputDialog)
 
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
 UI_FILE = os.path.join(os.path.dirname(__file__), 'mainwindow.ui')
 MainWindowUI, MainWindowBase = uic.loadUiType(UI_FILE)

--- a/examples/centralwidget/main.py
+++ b/examples/centralwidget/main.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (QApplication, QLabel, QCalendarWidget, QFrame, QTre
                              QTableWidget, QFileSystemModel, QPlainTextEdit, QToolBar,
                              QWidgetAction, QComboBox, QAction, QSizePolicy, QInputDialog)
 
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
 UI_FILE = os.path.join(os.path.dirname(__file__), 'mainwindow.ui')
 MainWindowUI, MainWindowBase = uic.loadUiType(UI_FILE)

--- a/examples/deleteonclose/main.py
+++ b/examples/deleteonclose/main.py
@@ -1,6 +1,6 @@
 import sys
 
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtCore import (qDebug, pyqtSlot, QObject, pyqtSignal)
 from PyQt5.QtWidgets import (QMainWindow, QAction, QTextEdit, QApplication,

--- a/examples/dockindock/dockindock.py
+++ b/examples/dockindock/dockindock.py
@@ -3,7 +3,7 @@ import sys
 from PyQt5.QtWidgets import (QApplication, QWidget, QVBoxLayout, QMessageBox,
                              QInputDialog, QMenu, QLineEdit)
 from PyQt5.QtGui import QIcon
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
 from dockindockmanager import DockInDockManager
 from perspectiveactions import LoadPerspectiveAction, RemovePerspectiveAction

--- a/examples/dockindock/dockindockmanager.py
+++ b/examples/dockindock/dockindockmanager.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import QAction, QMenu, QInputDialog, QLineEdit
 from PyQt5.QtCore import QSettings
 
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
 CHILD_PREFIX = "Child-"
 

--- a/examples/dockindock/main.py
+++ b/examples/dockindock/main.py
@@ -4,7 +4,7 @@ import atexit
 
 from PyQt5.QtWidgets import QApplication, QMainWindow, QLabel
 from PyQt5.QtCore import Qt
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
 from perspectives import PerspectivesManager
 from dockindock import DockInDockWidget

--- a/examples/dockindock/perspectives.py
+++ b/examples/dockindock/perspectives.py
@@ -4,7 +4,7 @@ import shutil
 import atexit
 
 from PyQt5.QtCore import pyqtSignal, QSettings, QObject
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
 from dockindockmanager import DockInDockManager
 from dockindock import DockInDockWidget

--- a/examples/emptydockarea/main.py
+++ b/examples/emptydockarea/main.py
@@ -6,7 +6,7 @@ from PyQt5.QtCore import Qt, QSignalBlocker
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QLabel, QComboBox, QTableWidget,
                              QAction, QWidgetAction, QSizePolicy, QInputDialog)
 from PyQt5.QtGui import QCloseEvent
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
     
 UI_FILE = os.path.join(os.path.dirname(__file__), 'mainwindow.ui')

--- a/examples/sidebar/main.py
+++ b/examples/sidebar/main.py
@@ -5,7 +5,7 @@ from PyQt5 import uic
 from PyQt5.QtCore import Qt, QMargins
 from PyQt5.QtWidgets import QApplication, QLabel, QVBoxLayout, QPlainTextEdit
 
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
 UI_FILE = os.path.join(os.path.dirname(__file__), 'MainWindow.ui')
 MainWindowUI, MainWindowBase = uic.loadUiType(UI_FILE)

--- a/examples/simple/main.py
+++ b/examples/simple/main.py
@@ -6,7 +6,7 @@ from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import QApplication, QLabel
 
-from PyQtAds import QtAds
+import PyQtAds as QtAds
 
 UI_FILE = os.path.join(os.path.dirname(__file__), 'MainWindow.ui')
 MainWindowUI, MainWindowBase = uic.loadUiType(UI_FILE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 # Specify the build system.
 [build-system]
-requires = ["sip >=6.0.2, <6.3", "PyQt-builder >=1.6, <2", "PyQt5==5.15.4", "PyQt5-sip<13,>=12.8"]
+requires = ["sip >=6.0.2", "PyQt-builder >=1.6", "PyQt5>=5.15", "PyQt5-sip>=12.8"]
 build-backend = "sipbuild.api"
 
 # Specify the PEP 566 metadata for the project.
 [tool.sip.metadata]
 name = "PyQtAds"
-version = "4.0.2"
+version = "4.4.1"
 summary = "Python bindings for Qt Advanced Docking System"
 home-page = "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/"
 license = "LGPL v2.1"
@@ -21,6 +21,7 @@ tag-prefix = "QtAds"
 define-macros = ["ADS_SHARED_EXPORT"]
 sip-file = "ads.sip"
 include-dirs = ["src"]
+pep484-pyi = true
 qmake-QT = ["widgets", "gui-private; platform_system == 'Linux'"]
 headers = [
     "src/AutoHideDockContainer.h",

--- a/sip/AutoHideTab.sip
+++ b/sip/AutoHideTab.sip
@@ -5,7 +5,7 @@
 namespace ads
 {
 
-class CAutoHideTab : CPushButton
+class CAutoHideTab : ads::CPushButton
 {
     
     %TypeHeaderCode

--- a/sip/ads.sip
+++ b/sip/ads.sip
@@ -1,4 +1,5 @@
-%Module(name=PyQtAds, call_super_init=True, keyword_arguments="Optional", use_limited_api=True)
+%Module(name=PyQtAds.ads, call_super_init=True, keyword_arguments="Optional", use_limited_api=True)
+
 %Import QtCore/QtCoremod.sip
 %DefaultSupertype sip.simplewrapper
 


### PR DESCRIPTION
Hi!

The following patches do a few things:

- Fix the version number in the pyproject.toml.
- Generate type hints for the pyi files.
- Makes QtAds sip builds functional in Python.
- Reduces the unnecessary depth of the python package.

NOTE: This is a breaking change for python users, where, `from PyQtAds import QtAds` is changed to `import PyQtAds as QtAds` (or simply `import PyQtAds`)

Please let me know if this looks good.


Thanks,
Nate