### PR TITLE
Add option to set custom icon for auto hide mode

### DIFF
--- a/examples/autohide/CMakeLists.txt
+++ b/examples/autohide/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(AutoHideExample WIN32
     main.cpp
     mainwindow.cpp
     mainwindow.ui
+    autohide.qrc
 )
 target_include_directories(AutoHideExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 target_link_libraries(AutoHideExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)

--- a/examples/autohide/autohide.pro
+++ b/examples/autohide/autohide.pro
@@ -27,6 +27,9 @@ HEADERS += \
 FORMS += \
     mainwindow.ui
 
+RESOURCES += \
+    autohide.qrc
+
 LIBS += -L$${ADS_OUT_ROOT}/lib
 include(../../ads.pri)
 INCLUDEPATH += ../../src

--- a/examples/autohide/autohide.qrc
+++ b/examples/autohide/autohide.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="adsautohide">
+        <file>images/minimize-button.svg</file>
+    </qresource>
+</RCC>

--- a/examples/autohide/autohide.qrc
+++ b/examples/autohide/autohide.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="adsautohide">
         <file>images/minimize-button.svg</file>
+        <file>res/autohide.css</file>
     </qresource>
 </RCC>

--- a/examples/autohide/images/minimize-button.svg
+++ b/examples/autohide/images/minimize-button.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   sodipodi:docname="minimize-button.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 16 16"
+   height="16px"
+   width="16px"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <style
+     id="style2" />
+  <defs
+     id="defs4">
+    <pattern
+       id="EMFhbasepattern"
+       patternUnits="userSpaceOnUse"
+       width="6"
+       height="6"
+       x="0"
+       y="0" />
+    <pattern
+       id="EMFhbasepattern-4"
+       patternUnits="userSpaceOnUse"
+       width="6"
+       height="6"
+       x="0"
+       y="0" />
+    <pattern
+       id="EMFhbasepattern-3"
+       patternUnits="userSpaceOnUse"
+       width="6"
+       height="6"
+       x="0"
+       y="0" />
+    <pattern
+       id="EMFhbasepattern-8"
+       patternUnits="userSpaceOnUse"
+       width="6"
+       height="6"
+       x="0"
+       y="0" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:guide-bbox="true"
+     showguides="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-6"
+     inkscape:window-x="-6"
+     inkscape:window-height="1018"
+     inkscape:window-width="1920"
+     units="px"
+     showgrid="true"
+     inkscape:current-layer="g5228"
+     inkscape:document-units="px"
+     inkscape:cy="11.170077"
+     inkscape:cx="6.4744465"
+     inkscape:zoom="45.254834"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       id="grid3336"
+       type="xygrid" />
+    <sodipodi:guide
+       id="guide883"
+       orientation="1,0"
+       position="4,10" />
+    <sodipodi:guide
+       id="guide885"
+       orientation="0,-1"
+       position="10,12" />
+    <sodipodi:guide
+       id="guide887"
+       orientation="1,0"
+       position="12,2" />
+    <sodipodi:guide
+       id="guide889"
+       orientation="0,-1"
+       position="14,4" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-1036.3622)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <g
+       id="g5228"
+       transform="translate(628,-140.49998)">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke-width:1.41421"
+         id="rect964"
+         width="8"
+         height="2.0000026"
+         x="-624"
+         y="1186.8622"
+         ry="1.0000013" />
+    </g>
+  </g>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <rdf:Description
+         dc:language="en"
+         dc:format="image/svg+xml"
+         dc:date="2016-12-14"
+         dc:publisher="Iconscout"
+         dc:description="Menu, Bar, Lines, Option, List, Hamburger, Web"
+         dc:title="Menu, Bar, Lines, Option, List, Hamburger, Web"
+         about="https://iconscout.com/legal#licenses">
+        <dc:creator>
+          <rdf:Bag>
+            <rdf:li>Jemis Mali</rdf:li>
+          </rdf:Bag>
+        </dc:creator>
+      </rdf:Description>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/examples/autohide/mainwindow.cpp
+++ b/examples/autohide/mainwindow.cpp
@@ -34,6 +34,13 @@ CMainWindow::CMainWindow(QWidget *parent)
 
     DockManager = new CDockManager(this);
 
+    QFile StyleSheetFile(":/adsautohide/res/autohide.css");
+    StyleSheetFile.open(QIODevice::ReadOnly);
+    QTextStream StyleSheetStream(&StyleSheetFile);
+    auto Stylesheet = StyleSheetStream.readAll();
+    StyleSheetFile.close();
+    DockManager->setStyleSheet(Stylesheet);
+
     // Set central widget
     QPlainTextEdit* w = new QPlainTextEdit();
 	w->setPlaceholderText("This is the central editor. Enter your text here.");

--- a/examples/autohide/mainwindow.cpp
+++ b/examples/autohide/mainwindow.cpp
@@ -14,7 +14,7 @@
 
 #include "AutoHideDockContainer.h"
 #include "DockAreaWidget.h"
-#include "DockAreaTitleBar.h"
+#include "IconProvider.h"
 
 using namespace ads;
 
@@ -28,6 +28,10 @@ CMainWindow::CMainWindow(QWidget *parent)
     CDockManager::setConfigFlag(CDockManager::XmlCompressionEnabled, false);
     CDockManager::setConfigFlag(CDockManager::FocusHighlighting, true);
     CDockManager::setAutoHideConfigFlags(CDockManager::DefaultAutoHideConfig);
+    CDockManager::setAutoHideConfigFlag(CDockManager::AutoHideCloseButtonCollapsesDock, true);
+    CDockManager::iconProvider().registerCustomIcon(AutoHideDockAreaCloseIcon, 
+        QIcon(":/adsautohide/images/minimize-button.svg"));
+
     DockManager = new CDockManager(this);
 
     // Set central widget

--- a/examples/autohide/res/autohide.css
+++ b/examples/autohide/res/autohide.css
@@ -1,0 +1,368 @@
+/*
+ * Default style sheet on Windows Platforms with focus highlighting flag enabled
+ */
+
+
+/*****************************************************************************
+ * CDockContainerWidget
+ *****************************************************************************/
+ads--CDockContainerWidget {
+    background: palette(window);
+}
+
+
+    /*****************************************************************************
+ * CDockSplitter
+ *****************************************************************************/
+    ads--CDockContainerWidget > QSplitter {
+        padding: 1 0 1 0;
+    }
+
+
+ads--CDockSplitter::handle {
+    background-color: palette(dark);
+    /* uncomment the following line if you would like to change the size of
+       the splitter handles */
+    /* height: 1px; */
+}
+
+
+/*****************************************************************************
+ * CDockAreaWidget
+ *****************************************************************************/
+ads--CDockAreaWidget {
+    background: palette(window);
+}
+
+
+ads--CDockAreaTitleBar {
+    background: transparent;
+    border-bottom: 2px solid palette(light);
+    padding-bottom: 0px;
+}
+
+ads--CDockAreaWidget[focused="true"] ads--CDockAreaTitleBar {
+    border-bottom: 2px solid palette(highlight);
+}
+
+ads--CTitleBarButton {
+    padding: 0px 0px;
+}
+
+
+#tabsMenuButton::menu-indicator {
+    image: none;
+}
+
+
+#dockAreaCloseButton {
+    qproperty-iconSize: 16px;
+}
+
+#detachGroupButton {
+    qproperty-icon: url(:/ads/images/detach-button.svg), url(:/ads/images/detach-button-disabled.svg) disabled;
+    qproperty-iconSize: 16px;
+}
+
+
+
+/*****************************************************************************
+ * CDockWidgetTab
+ *****************************************************************************/
+ads--CDockWidgetTab {
+    background: palette(window);
+    border-color: palette(light);
+    border-style: solid;
+    border-width: 0 1px 0 0;
+    padding: 0 0px;
+    qproperty-iconSize: 16px 16px; /* this is optional in case you would like to change icon size*/
+}
+
+    ads--CDockWidgetTab[activeTab="true"] {
+        background: qlineargradient(spread : pad, x1 : 0, y1 : 0, x2 : 0, y2 : 0.5, stop : 0 palette(window), stop:1 palette(light));
+        /*background: palette(highlight);*/
+    }
+
+    ads--CDockWidgetTab QLabel {
+        color: palette(dark);
+    }
+
+    ads--CDockWidgetTab[activeTab="true"] QLabel {
+        color: palette(foreground);
+    }
+
+
+#tabCloseButton {
+    margin-top: 2px;
+    background: none;
+    border: none;
+    padding: 0px -2px;
+    qproperty-icon: url(:/ads/images/close-button.svg), url(:/ads/images/close-button-disabled.svg) disabled;
+    qproperty-iconSize: 16px;
+}
+
+    #tabCloseButton:hover {
+        /*border: 1px solid rgba(0, 0, 0, 32);*/
+        background: rgba(0, 0, 0, 24);
+    }
+
+    #tabCloseButton:pressed {
+        background: rgba(0, 0, 0, 48);
+    }
+
+/* Focus related styling */
+ads--CDockWidgetTab[focused="true"] {
+    background: palette(highlight);
+    border-color: palette(highlight);
+}
+
+    ads--CDockWidgetTab[focused="true"] > #tabCloseButton {
+        qproperty-icon: url(:/ads/images/close-button-focused.svg)
+    }
+
+        ads--CDockWidgetTab[focused="true"] > #tabCloseButton:hover {
+            background: rgba(255, 255, 255, 48);
+        }
+
+        ads--CDockWidgetTab[focused="true"] > #tabCloseButton:pressed {
+            background: rgba(255, 255, 255, 92);
+        }
+
+    ads--CDockWidgetTab[focused="true"] QLabel {
+        color: palette(light);
+    }
+
+
+
+/*****************************************************************************
+ * CDockWidget
+ *****************************************************************************/
+ads--CDockWidget {
+    background: palette(light);
+    border-color: palette(light);
+    border-style: solid;
+    border-width: 1px 0 0 0;
+}
+
+
+QScrollArea#dockWidgetScrollArea {
+    padding: 0px;
+    border: none;
+}
+
+
+
+/*****************************************************************************
+ *
+ * Styling of auto hide functionality
+ *
+ *****************************************************************************/
+
+
+/*****************************************************************************
+ * CAutoHideTab
+ *****************************************************************************/
+ads--CAutoHideTab {
+    qproperty-iconSize: 16px 16px; /* this is optional in case you would like to change icon size*/
+    background: none;
+    border: none;
+    padding-left: 2px;
+    padding-right: 0px;
+    text-align: center;
+    min-height: 20px;
+    padding-bottom: 2px;
+}
+
+
+    ads--CAutoHideTab:hover {
+        color: palette(highlight);
+    }
+
+
+    ads--CAutoHideTab[iconOnly="false"][sideBarLocation="0"],
+    ads--CAutoHideTab[iconOnly="false"][sideBarLocation="2"] {
+        border-top: 6px solid rgba(0, 0, 0, 48);
+    }
+
+
+    ads--CAutoHideTab[iconOnly="false"][sideBarLocation="1"],
+    ads--CAutoHideTab[iconOnly="false"][sideBarLocation="3"] {
+        border-bottom: 6px solid rgba(0, 0, 0, 48);
+    }
+
+
+
+    ads--CAutoHideTab:hover[iconOnly="false"][sideBarLocation="0"],
+    ads--CAutoHideTab:hover[iconOnly="false"][sideBarLocation="2"],
+    ads--CAutoHideTab[iconOnly="false"][sideBarLocation="0"][activeTab="true"],
+    ads--CAutoHideTab[iconOnly="false"][sideBarLocation="2"][activeTab="true"] {
+        border-top: 6px solid palette(highlight);
+    }
+
+
+    ads--CAutoHideTab:hover[iconOnly="false"][sideBarLocation="1"],
+    ads--CAutoHideTab:hover[iconOnly="false"][sideBarLocation="3"],
+    ads--CAutoHideTab[iconOnly="false"][sideBarLocation="1"][activeTab="true"],
+    ads--CAutoHideTab[iconOnly="false"][sideBarLocation="3"][activeTab="true"] {
+        border-bottom: 6px solid palette(highlight);
+    }
+
+
+    /**
+ * Auto hide tabs with icon only
+ */
+    ads--CAutoHideTab[iconOnly="true"][sideBarLocation="0"] {
+        border-top: 6px solid rgba(0, 0, 0, 48);
+    }
+
+    ads--CAutoHideTab[iconOnly="true"][sideBarLocation="1"] {
+        border-left: 6px solid rgba(0, 0, 0, 48);
+    }
+
+    ads--CAutoHideTab[iconOnly="true"][sideBarLocation="2"] {
+        border-right: 6px solid rgba(0, 0, 0, 48);
+    }
+
+    ads--CAutoHideTab[iconOnly="true"][sideBarLocation="3"] {
+        border-bottom: 6px solid rgba(0, 0, 0, 48);
+    }
+
+
+    /**
+ * Auto hide tabs with icon only hover
+ */
+    ads--CAutoHideTab:hover[iconOnly="true"][sideBarLocation="0"],
+    ads--CAutoHideTab[iconOnly="true"][sideBarLocation="0"][activeTab="true"] {
+        border-top: 6px solid palette(highlight);
+    }
+
+    ads--CAutoHideTab:hover[iconOnly="true"][sideBarLocation="1"],
+    ads--CAutoHideTab[iconOnly="true"][sideBarLocation="1"][activeTab="true"] {
+        border-left: 6px solid palette(highlight);
+    }
+
+    ads--CAutoHideTab:hover[iconOnly="true"][sideBarLocation="2"],
+    ads--CAutoHideTab[iconOnly="true"][sideBarLocation="2"][activeTab="true"] {
+        border-right: 6px solid palette(highlight);
+    }
+
+    ads--CAutoHideTab:hover[iconOnly="true"][sideBarLocation="3"],
+    ads--CAutoHideTab[iconOnly="true"][sideBarLocation="3"][activeTab="true"] {
+        border-bottom: 6px solid palette(highlight);
+    }
+
+
+
+/*****************************************************************************
+ * CAutoHideSideBar
+ *****************************************************************************/
+ads--CAutoHideSideBar {
+    background: palette(window);
+    border: none;
+    qproperty-spacing: 12;
+}
+
+#sideTabsContainerWidget {
+    background: transparent;
+}
+
+
+ads--CAutoHideSideBar[sideBarLocation="0"] {
+    border-bottom: 1px solid palette(dark);
+}
+
+ads--CAutoHideSideBar[sideBarLocation="1"] {
+    border-right: 1px solid palette(dark);
+}
+
+ads--CAutoHideSideBar[sideBarLocation="2"] {
+    border-left: 1px solid palette(dark);
+}
+
+ads--CAutoHideSideBar[sideBarLocation="3"] {
+    border-top: 1px solid palette(dark);
+}
+
+
+/*****************************************************************************
+ * CAutoHideDockContainer
+ *****************************************************************************/
+ads--CAutoHideDockContainer {
+    background: palette(window);
+}
+
+
+    ads--CAutoHideDockContainer ads--CDockAreaTitleBar {
+        background: palette(highlight);
+        padding: 0px;
+        border: none;
+    }
+
+
+    /*
+ * This is required because the ads--CDockAreaWidget[focused="true"] will 
+ * overwrite the ads--CAutoHideDockContainer ads--CDockAreaTitleBar rule
+ */
+    ads--CAutoHideDockContainer ads--CDockAreaWidget[focused="true"] ads--CDockAreaTitleBar {
+        background: palette(highlight);
+        padding: 0px;
+        border: none;
+    }
+
+
+#autoHideTitleLabel {
+    padding-left: 4px;
+    color: palette(light);
+}
+
+
+/*****************************************************************************
+ * CAutoHideDockContainer titlebar buttons
+ *****************************************************************************/
+#dockAreaAutoHideButton {
+    qproperty-icon: url(:/ads/images/vs-pin-button.svg);
+    qproperty-iconSize: 16px;
+}
+
+ads--CAutoHideDockContainer #dockAreaAutoHideButton {
+    qproperty-icon: url(:/ads/images/vs-pin-button-pinned-focused.svg);
+    qproperty-iconSize: 16px;
+}
+
+
+ads--CAutoHideDockContainer ads--CTitleBarButton:hover {
+    background: rgba(255, 255, 255, 48);
+}
+
+ads--CAutoHideDockContainer ads--CTitleBarButton:pressed {
+    background: rgba(255, 255, 255, 96);
+}
+
+/*****************************************************************************
+ * CAutoHideDockContainer Titlebar and Buttons
+ *****************************************************************************/
+
+
+/*****************************************************************************
+ * CResizeHandle
+ *****************************************************************************/
+ads--CResizeHandle {
+    background: palette(window);
+}
+
+
+ads--CAutoHideDockContainer[sideBarLocation="0"] ads--CResizeHandle {
+    border-top: 1px solid palette(dark);
+}
+
+ads--CAutoHideDockContainer[sideBarLocation="1"] ads--CResizeHandle {
+    border-left: 1px solid palette(dark);
+}
+
+ads--CAutoHideDockContainer[sideBarLocation="2"] ads--CResizeHandle {
+    border-right: 1px solid palette(dark);
+}
+
+ads--CAutoHideDockContainer[sideBarLocation="3"] ads--CResizeHandle {
+    border-top: 1px solid palette(dark);
+}

--- a/sip/ads_globals.sip
+++ b/sip/ads_globals.sip
@@ -94,6 +94,15 @@ namespace ads
         IconCount,
     };
 
+    enum eAutoHideIcon
+    {
+        AutoHideAutoHideIcon,
+        AutoHideDockAreaMenuIcon,
+        AutoHideDockAreaUndockIcon,
+        AutoHideDockAreaCloseIcon,
+        AutoHideIconCount,
+    };
+
     enum eBitwiseOperator
     {
         BitwiseAnd,

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -182,7 +182,7 @@ void DockAreaTitleBarPrivate::createButtons()
 	TabsMenuButton->setObjectName("tabsMenuButton");
 	TabsMenuButton->setAutoRaise(true);
 	TabsMenuButton->setPopupMode(QToolButton::InstantPopup);
-	internal::setButtonIcon(TabsMenuButton, QStyle::SP_TitleBarUnshadeButton, ads::DockAreaMenuIcon);
+	internal::setButtonIcon(TabsMenuButton, QStyle::SP_TitleBarUnshadeButton, _this->titleBarButtonCustomIcon(TitleBarButtonTabsMenu));
 	QMenu* TabsMenu = new QMenu(TabsMenuButton);
 #ifndef QT_NO_TOOLTIP
 	TabsMenu->setToolTipsVisible(true);
@@ -200,7 +200,7 @@ void DockAreaTitleBarPrivate::createButtons()
 	UndockButton->setObjectName("detachGroupButton");
 	UndockButton->setAutoRaise(true);
 	internal::setToolTip(UndockButton, QObject::tr("Detach Group"));
-	internal::setButtonIcon(UndockButton, QStyle::SP_TitleBarNormalButton, ads::DockAreaUndockIcon);
+	internal::setButtonIcon(UndockButton, QStyle::SP_TitleBarNormalButton, _this->titleBarButtonCustomIcon(TitleBarButtonUndock));
 	UndockButton->setSizePolicy(ButtonSizePolicy);
 	Layout->addWidget(UndockButton, 0);
 	_this->connect(UndockButton, SIGNAL(clicked()), SLOT(onUndockButtonClicked()));
@@ -211,7 +211,7 @@ void DockAreaTitleBarPrivate::createButtons()
 	AutoHideButton->setObjectName("dockAreaAutoHideButton");
 	AutoHideButton->setAutoRaise(true);
 	internal::setToolTip(AutoHideButton, _this->titleBarButtonToolTip(TitleBarButtonAutoHide));
-	internal::setButtonIcon(AutoHideButton, QStyle::SP_DialogOkButton, ads::AutoHideIcon);
+	internal::setButtonIcon(AutoHideButton, QStyle::SP_DialogOkButton, _this->titleBarButtonCustomIcon(TitleBarButtonAutoHide));
 	AutoHideButton->setSizePolicy(ButtonSizePolicy);
 	AutoHideButton->setCheckable(testAutoHideConfigFlag(CDockManager::AutoHideButtonCheckable));
 	AutoHideButton->setChecked(false);
@@ -222,7 +222,7 @@ void DockAreaTitleBarPrivate::createButtons()
 	CloseButton = new CTitleBarButton(testConfigFlag(CDockManager::DockAreaHasCloseButton));
 	CloseButton->setObjectName("dockAreaCloseButton");
 	CloseButton->setAutoRaise(true);
-	internal::setButtonIcon(CloseButton, QStyle::SP_TitleBarCloseButton, ads::DockAreaCloseIcon);
+	internal::setButtonIcon(CloseButton, QStyle::SP_TitleBarCloseButton, _this->titleBarButtonCustomIcon(TitleBarButtonClose));
     internal::setToolTip(CloseButton, _this->titleBarButtonToolTip(TitleBarButtonClose));
 	CloseButton->setSizePolicy(ButtonSizePolicy);
 	CloseButton->setIconSize(QSize(16, 16));
@@ -829,6 +829,74 @@ QString CDockAreaTitleBar::titleBarButtonToolTip(TitleBarButton Button) const
 	}
 
 	return QString();
+}
+
+
+//============================================================================
+QIcon getAutoHideCustomIcon(TitleBarButton Button)
+{
+	switch (Button)
+	{
+	case TitleBarButtonTabsMenu:
+	{
+		return CDockManager::iconProvider().customIcon(AutoHideDockAreaMenuIcon);
+	}
+	case TitleBarButtonUndock:
+	{
+		return CDockManager::iconProvider().customIcon(AutoHideDockAreaUndockIcon);
+	}
+	case TitleBarButtonClose:
+	{
+		return CDockManager::iconProvider().customIcon(AutoHideDockAreaCloseIcon);
+	}
+	case TitleBarButtonAutoHide:
+	{
+		return CDockManager::iconProvider().customIcon(AutoHideAutoHideIcon);
+	}
+	}
+	return {};
+}
+
+
+//============================================================================
+QIcon getCustomIcon(TitleBarButton Button)
+{
+	switch (Button)
+	{
+	case TitleBarButtonTabsMenu:
+	{
+		return CDockManager::iconProvider().customIcon(DockAreaMenuIcon);
+	}
+	case TitleBarButtonUndock:
+	{
+		return CDockManager::iconProvider().customIcon(DockAreaUndockIcon);
+	}
+	case TitleBarButtonClose:
+	{
+		return CDockManager::iconProvider().customIcon(DockAreaCloseIcon);
+	}
+	case TitleBarButtonAutoHide:
+	{
+		return CDockManager::iconProvider().customIcon(AutoHideIcon);
+	}
+	}
+	return {};
+}
+
+
+//============================================================================
+QIcon CDockAreaTitleBar::titleBarButtonCustomIcon(TitleBarButton Button) const
+{
+	QIcon icon;
+	if (d->DockArea != nullptr && d->DockArea->isAutoHide())
+	{
+		icon = getAutoHideCustomIcon(Button);
+	}
+	if (icon.isNull())
+	{
+		icon = getCustomIcon(Button);
+	}
+	return icon;
 }
 
 //============================================================================

--- a/src/DockAreaTitleBar.h
+++ b/src/DockAreaTitleBar.h
@@ -205,6 +205,11 @@ public:
 	QString titleBarButtonToolTip(TitleBarButton Button) const;
 
 	/**
+	 * Custom icon based on the current state
+	 */
+	QIcon titleBarButtonCustomIcon(TitleBarButton Button) const;
+
+	/**
 	 * Moves the dock area into its own floating widget if the area
 	 * DockWidgetFloatable flag is true
 	 */

--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -467,6 +467,7 @@ void CDockAreaWidget::setAutoHideDockContainer(CAutoHideDockContainer* AutoHideD
 	d->AutoHideDockContainer = AutoHideDockContainer;
 	updateAutoHideButtonCheckState();
 	updateTitleBarButtonsToolTips();
+	updateTitleBarButtonsIcons();
 	d->TitleBar->button(TitleBarButtonAutoHide)->setShowInTitleBar(true);
 }
 
@@ -891,6 +892,21 @@ void CDockAreaWidget::updateTitleBarButtonsToolTips()
 		titleBar()->titleBarButtonToolTip(TitleBarButtonAutoHide));
 }
 
+void CDockAreaWidget::updateTitleBarButtonsIcons()
+{
+	internal::setButtonIcon(titleBarButton(TitleBarButtonTabsMenu), 
+		QStyle::SP_TitleBarUnshadeButton, 
+		titleBar()->titleBarButtonCustomIcon(TitleBarButtonTabsMenu));
+	internal::setButtonIcon(titleBarButton(TitleBarButtonUndock), 
+		QStyle::SP_TitleBarNormalButton, 
+		titleBar()->titleBarButtonCustomIcon(TitleBarButtonUndock));
+	internal::setButtonIcon(titleBarButton(TitleBarButtonClose), 
+		QStyle::SP_TitleBarCloseButton, 
+		titleBar()->titleBarButtonCustomIcon(TitleBarButtonClose));
+	internal::setButtonIcon(titleBarButton(TitleBarButtonAutoHide), 
+		QStyle::SP_DialogOkButton, 
+		titleBar()->titleBarButtonCustomIcon(TitleBarButtonAutoHide));
+}
 
 //============================================================================
 void CDockAreaWidget::saveState(QXmlStreamWriter& s) const

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -89,6 +89,11 @@ private Q_SLOTS:
 	 */
 	void updateTitleBarButtonsToolTips();
 
+	/*
+	 * Update the title bar button icons
+	 */
+	void updateTitleBarButtonsIcons();
+
 	/**
 	 * Calculate the auto hide side bar location depending on the dock area
 	 * widget position in the container

--- a/src/IconProvider.cpp
+++ b/src/IconProvider.cpp
@@ -20,6 +20,7 @@ struct IconProviderPrivate
 {
 	CIconProvider *_this;
 	QVector<QIcon> UserIcons{IconCount, QIcon()};
+	QVector<QIcon> UserAutoHideIcons{AutoHideIconCount, QIcon()};
 
 	/**
 	 * Private data constructor
@@ -58,10 +59,26 @@ QIcon CIconProvider::customIcon(eIcon IconId) const
 
 
 //============================================================================
+QIcon CIconProvider::customIcon(eAutoHideIcon IconId) const
+{
+	Q_ASSERT(IconId < d->UserAutoHideIcons.size());
+	return d->UserAutoHideIcons[IconId];
+}
+
+
+//============================================================================
 void CIconProvider::registerCustomIcon(eIcon IconId, const QIcon &icon)
 {
 	Q_ASSERT(IconId < d->UserIcons.size());
 	d->UserIcons[IconId] = icon;
+}
+
+
+//============================================================================
+void CIconProvider::registerCustomIcon(eAutoHideIcon IconId, const QIcon &icon)
+{
+	Q_ASSERT(IconId < d->UserAutoHideIcons.size());
+	d->UserAutoHideIcons[IconId] = icon;
 }
 
 } // namespace ads

--- a/src/IconProvider.h
+++ b/src/IconProvider.h
@@ -47,11 +47,13 @@ public:
 	 * if no custom icon is registered
 	 */
 	QIcon customIcon(eIcon IconId) const;
+    QIcon customIcon(eAutoHideIcon IconId) const;
 
-	/**
+    /**
 	 * Registers a custom icon for the given IconId
 	 */
 	void registerCustomIcon(eIcon IconId, const QIcon &icon);
+	void registerCustomIcon(eAutoHideIcon IconId, const QIcon& icon);
 }; // class IconProvider
 
 } // namespace ads

--- a/src/IconProvider.h
+++ b/src/IconProvider.h
@@ -47,9 +47,9 @@ public:
 	 * if no custom icon is registered
 	 */
 	QIcon customIcon(eIcon IconId) const;
-    QIcon customIcon(eAutoHideIcon IconId) const;
+	QIcon customIcon(eAutoHideIcon IconId) const;
 
-    /**
+	/**
 	 * Registers a custom icon for the given IconId
 	 */
 	void registerCustomIcon(eIcon IconId, const QIcon &icon);

--- a/src/ads_globals.cpp
+++ b/src/ads_globals.cpp
@@ -412,17 +412,35 @@ void setButtonIcon(QAbstractButton* Button, QStyle::StandardPixmap StandarPixmap
 		return;
 	}
 
+	Button->setIcon(getStandardPixmapIcon(Button, StandarPixmap));
+}
+
+void setButtonIcon(QAbstractButton *Button, QStyle::StandardPixmap StandardPixmap, QIcon Icon)
+ {
+	// First we try to use custom icons if available
+	if (!Icon.isNull())
+	{
+		Button->setIcon(Icon);
+		return;
+	}
+	Button->setIcon(getStandardPixmapIcon(Button, StandardPixmap));
+ }
+
+//============================================================================
+QIcon getStandardPixmapIcon(QAbstractButton* Button, QStyle::StandardPixmap Pixmap)
+ {
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-	Button->setIcon(Button->style()->standardIcon(StandarPixmap));
+	return Button->style()->standardIcon(Pixmap);
 #else
 	// The standard icons does not look good on high DPI screens so we create
 	// our own "standard" icon here.
-	QPixmap normalPixmap = Button->style()->standardPixmap(StandarPixmap, 0, Button);
-	Icon.addPixmap(internal::createTransparentPixmap(normalPixmap, 0.25), QIcon::Disabled);
-	Icon.addPixmap(normalPixmap, QIcon::Normal);
-	Button->setIcon(Icon);
+    const QPixmap normalPixmap = Button->style()->standardPixmap(Pixmap, 0, Button);
+	QIcon icon;
+	icon.addPixmap(internal::createTransparentPixmap(normalPixmap, 0.25), QIcon::Disabled);
+	icon.addPixmap(normalPixmap, QIcon::Normal);
+	return icon;
 #endif
-}
+ }
 
 
 //============================================================================

--- a/src/ads_globals.cpp
+++ b/src/ads_globals.cpp
@@ -415,8 +415,10 @@ void setButtonIcon(QAbstractButton* Button, QStyle::StandardPixmap StandarPixmap
 	Button->setIcon(getStandardPixmapIcon(Button, StandarPixmap));
 }
 
+
+//============================================================================
 void setButtonIcon(QAbstractButton *Button, QStyle::StandardPixmap StandardPixmap, QIcon Icon)
- {
+{
 	// First we try to use custom icons if available
 	if (!Icon.isNull())
 	{
@@ -424,23 +426,24 @@ void setButtonIcon(QAbstractButton *Button, QStyle::StandardPixmap StandardPixma
 		return;
 	}
 	Button->setIcon(getStandardPixmapIcon(Button, StandardPixmap));
- }
+}
+
 
 //============================================================================
-QIcon getStandardPixmapIcon(QAbstractButton* Button, QStyle::StandardPixmap Pixmap)
- {
+QIcon getStandardPixmapIcon(QAbstractButton* Button, QStyle::StandardPixmap StandardPixmap)
+{
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-	return Button->style()->standardIcon(Pixmap);
+	return Button->style()->standardIcon(StandardPixmap);
 #else
 	// The standard icons does not look good on high DPI screens so we create
 	// our own "standard" icon here.
-    const QPixmap normalPixmap = Button->style()->standardPixmap(Pixmap, 0, Button);
+	const QPixmap normalPixmap = Button->style()->standardPixmap(StandardPixmap, 0, Button);
 	QIcon icon;
 	icon.addPixmap(internal::createTransparentPixmap(normalPixmap, 0.25), QIcon::Disabled);
 	icon.addPixmap(normalPixmap, QIcon::Normal);
 	return icon;
 #endif
- }
+}
 
 
 //============================================================================

--- a/src/ads_globals.h
+++ b/src/ads_globals.h
@@ -136,6 +136,19 @@ enum eIcon
 };
 
 /**
+ * The different icons used in the UI for Auto Hide
+ */
+enum eAutoHideIcon
+{
+    AutoHideAutoHideIcon,      //!< AutoHideIcon
+	AutoHideDockAreaMenuIcon,  //!< DockAreaMenuIcon
+	AutoHideDockAreaUndockIcon,//!< DockAreaUndockIcon
+	AutoHideDockAreaCloseIcon, //!< DockAreaCloseIcon
+
+	AutoHideIconCount,         //!< just a delimiter for range checks
+};
+
+/**
  * For bitwise combination of dock wdget features
  */
 enum eBitwiseOperator
@@ -343,6 +356,14 @@ inline QPoint globalPositionOf(QMouseEvent* ev)
 void setButtonIcon(QAbstractButton* Button, QStyle::StandardPixmap StandarPixmap,
 	ads::eIcon CustomIconId);
 
+
+void setButtonIcon(QAbstractButton* Button, QStyle::StandardPixmap StandardPixmap, QIcon Icon);
+
+
+/**
+ * Return the icon of standard pixmap for button.
+ */
+QIcon getStandardPixmapIcon(QAbstractButton* Button, QStyle::StandardPixmap Pixmap);
 
 enum eRepolishChildOptions
 {

--- a/src/ads_globals.h
+++ b/src/ads_globals.h
@@ -140,10 +140,10 @@ enum eIcon
  */
 enum eAutoHideIcon
 {
-    AutoHideAutoHideIcon,      //!< AutoHideIcon
-	AutoHideDockAreaMenuIcon,  //!< DockAreaMenuIcon
-	AutoHideDockAreaUndockIcon,//!< DockAreaUndockIcon
-	AutoHideDockAreaCloseIcon, //!< DockAreaCloseIcon
+	AutoHideAutoHideIcon,      //!< AutoHideAutoHideIcon
+	AutoHideDockAreaMenuIcon,  //!< AutoHideDockAreaMenuIcon
+	AutoHideDockAreaUndockIcon,//!< AutoHideDockAreaUndockIcon
+	AutoHideDockAreaCloseIcon, //!< AutoHideDockAreaCloseIcon
 
 	AutoHideIconCount,         //!< just a delimiter for range checks
 };
@@ -357,13 +357,23 @@ void setButtonIcon(QAbstractButton* Button, QStyle::StandardPixmap StandarPixmap
 	ads::eIcon CustomIconId);
 
 
+/**
+ * Helper function to set the icon of a certain button.
+ * Use this function to set the icons for the dock area and dock widget buttons.
+ * If icon given is not a valid icon (icon is null), the function fetches the 
+ * given standard pixmap from the QStyle.
+ * param[in] Button The button whose icons are to be set
+ * param[in] StandardPixmap The standard pixmap to be used for the button
+ * param[in] Icon The custom icon
+ */
 void setButtonIcon(QAbstractButton* Button, QStyle::StandardPixmap StandardPixmap, QIcon Icon);
 
 
 /**
- * Return the icon of standard pixmap for button.
+ * Returns the standard pixmap icon for button from QStyle.
  */
 QIcon getStandardPixmapIcon(QAbstractButton* Button, QStyle::StandardPixmap Pixmap);
+
 
 enum eRepolishChildOptions
 {

--- a/src/stylesheets/focus_highlighting.css
+++ b/src/stylesheets/focus_highlighting.css
@@ -56,6 +56,8 @@ ads--CTitleBarButton {
 
 
 #dockAreaCloseButton {
+	qproperty-icon: url(:/ads/images/close-button.svg),
+		url(:/ads/images/close-button-disabled.svg) disabled;
 	qproperty-iconSize: 16px;
 }
 
@@ -335,6 +337,7 @@ ads--CAutoHideDockContainer #dockAreaAutoHideButton {
 
 
 ads--CAutoHideDockContainer #dockAreaCloseButton{
+	qproperty-icon: url(:/ads/images/close-button-focused.svg)
 }
 
 

--- a/src/stylesheets/focus_highlighting.css
+++ b/src/stylesheets/focus_highlighting.css
@@ -56,8 +56,6 @@ ads--CTitleBarButton {
 
 
 #dockAreaCloseButton {
-	qproperty-icon: url(:/ads/images/close-button.svg),
-		url(:/ads/images/close-button-disabled.svg) disabled;
 	qproperty-iconSize: 16px;
 }
 
@@ -337,7 +335,6 @@ ads--CAutoHideDockContainer #dockAreaAutoHideButton {
 
 
 ads--CAutoHideDockContainer #dockAreaCloseButton{
-	qproperty-icon: url(:/ads/images/close-button-focused.svg)
 }
 
 


### PR DESCRIPTION
Hi @githubuser0xFFFF ,

I have added some changes to registering custom icons, specifically for those used in auto hide mode. There is a new enum for the custom auto-hide icon IDs: `eAutoHideIcon`. If the user registers an icon for any of these IDs, the icon will be used when the dock is pinned (autohide mode). I have also added the use case in one of the examples.

https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/assets/30483309/c12ca275-9151-4663-a704-1fac0c6c8605

In the case of the video above, I have set the `AutoHideCloseButtonCollapsesDock` to true and also registered a custom icon (minimize icon) for the `AutoHideDockAreaCloseIcon`.

Thanks for reading, please let me know what you think :)
