### PR TITLE
Fix DockWidget crach when area is a nullptr.

### DIFF
--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -749,11 +749,10 @@ void CDockWidget::toggleViewInternal(bool Open)
 	if (d->DockArea)
 	{
 		d->DockArea->toggleDockWidgetView(this, Open);
-	}
-
-	if (d->DockArea->isAutoHide())
-	{
-		d->DockArea->autoHideDockContainer()->toggleView(Open);
+		if (d->DockArea->isAutoHide())
+		{
+			d->DockArea->autoHideDockContainer()->toggleView(Open);
+		}
 	}
 
 	if (Open && TopLevelDockWidgetBefore)


### PR DESCRIPTION
When requesting hide on a dockwidget that has been added to a dockmanager, but isn't yet visible, there was a creash. The crash has been fixed by moving the code to the existing guard check for the area.