### PR TITLE
Avoid dock manager double delete (crashes)

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -81,7 +81,7 @@ class CDockAreaLayout
 {
 private:
 	QBoxLayout* m_ParentLayout;
-	QList<QWidget*> m_Widgets;
+	QList<QPointer<QWidget>> m_Widgets;
 	int m_CurrentIndex = -1;
 	QWidget* m_CurrentWidget = nullptr;
 


### PR DESCRIPTION
If a dockwidget has been manually deleted, the dockmanager would delete it again when deleting the area in its dtor. 
The 'optimal' solution would likely have been changing CDockWidget::~CDockWidget to add
if (d->DockArea) d->DockArea->removeDockWidget(this); (before delete d).
However, it is not trivial (for me) to conclude that such a change would be safe on program shutdown.