### PR TITLE
Improve safety in code

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -756,7 +756,7 @@ int CDockAreaWidget::openDockWidgetsCount() const
 	int Count = 0;
 	for (int i = 0; i < d->ContentsLayout->count(); ++i)
 	{
-		if (!dockWidget(i)->isClosed())
+		if (dockWidget(i) && !dockWidget(i)->isClosed())
 		{
 			++Count;
 		}
@@ -772,7 +772,7 @@ QList<CDockWidget*> CDockAreaWidget::openedDockWidgets() const
 	for (int i = 0; i < d->ContentsLayout->count(); ++i)
 	{
 		CDockWidget* DockWidget = dockWidget(i);
-		if (!DockWidget->isClosed())
+		if (DockWidget && !DockWidget->isClosed())
 		{
 			DockWidgetList.append(dockWidget(i));
 		}
@@ -786,7 +786,7 @@ int CDockAreaWidget::indexOfFirstOpenDockWidget() const
 {
 	for (int i = 0; i < d->ContentsLayout->count(); ++i)
 	{
-		if (!dockWidget(i)->isClosed())
+		if (dockWidget(i) && !dockWidget(i)->isClosed())
 		{
 			return i;
 		}
@@ -808,7 +808,6 @@ CDockWidget* CDockAreaWidget::dockWidget(int Index) const
 {
 	return qobject_cast<CDockWidget*>(d->ContentsLayout->widget(Index));
 }
-
 
 //============================================================================
 void CDockAreaWidget::reorderDockWidget(int fromIndex, int toIndex)

--- a/src/DockFocusController.cpp
+++ b/src/DockFocusController.cpp
@@ -115,6 +115,7 @@ DockFocusControllerPrivate::DockFocusControllerPrivate(
 //============================================================================
 void DockFocusControllerPrivate::updateDockWidgetFocus(CDockWidget* DockWidget)
 {
+	if (!DockWidget) return;
 	if (!DockWidget->features().testFlag(CDockWidget::DockWidgetFocusable))
 	{
 		return;

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -81,7 +81,7 @@ struct DockWidgetPrivate
 	CDockWidgetTab* TabWidget = nullptr;
 	CDockWidget::DockWidgetFeatures Features = CDockWidget::DefaultDockWidgetFeatures;
 	CDockManager* DockManager = nullptr;
-	CDockAreaWidget* DockArea = nullptr;
+	QPointer<CDockAreaWidget> DockArea;
 	QAction* ToggleViewAction = nullptr;
 	bool Closed = false;
 	QScrollArea* ScrollArea = nullptr;


### PR DESCRIPTION
Delete areas later so that that they can be accessed by (inherited) dock widgets in dtor. Add some QPointer to prevent crashes.

Hence allow users to do more while dock widgets etc are being destroyed.