### PR TITLE
fix crash if autoHideDockContainer is not available

### DIFF
--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -1176,10 +1176,9 @@ bool DockContainerWidgetPrivate::restoreSideBar(CDockingStateReader& s,
 		}
 
 		auto SideBar = _this->autoHideSideBar(Area);
-		CAutoHideDockContainer* AutoHideContainer;
-		if (DockWidget->isAutoHide())
+		CAutoHideDockContainer* AutoHideContainer = DockWidget->autoHideDockContainer();
+		if (DockWidget->isAutoHide() && AutoHideContainer)
 		{
-			AutoHideContainer = DockWidget->autoHideDockContainer();
 			if (AutoHideContainer->autoHideSideBar() != SideBar)
 			{
 				SideBar->addAutoHideWidget(AutoHideContainer);


### PR DESCRIPTION
Steps to reproduce:

1) An Application with 2 docks, one is hidden, the second dock fills the main screen.
2) The second dock gets closed
3) the hidden dock gets visible, because not enough docks are visible (CAutoHideDockContainer::moveContentsToParent() will be called)
4) CDockManager::restoreState(). Were the state is the original view (One sidepanel with one autohidden dock) and a second dock fills the window

The application crashes without this fix. The problem is that for the first dock autohide is true, but because of the moveContentToParent it does not have any autoHideDockContainer() anymore.