### PR TITLE
Fix 'zero as null pointer constant' warnings

### DIFF
--- a/src/DockAreaTitleBar_p.h
+++ b/src/DockAreaTitleBar_p.h
@@ -52,7 +52,7 @@ class CSpacerWidget : public QWidget
 	Q_OBJECT
 public:
 	using Super = QWidget;
-	CSpacerWidget(QWidget* Parent = 0);
+	CSpacerWidget(QWidget* Parent = nullptr);
 	virtual QSize sizeHint() const override {return QSize(0, 0);}
 	virtual QSize minimumSizeHint() const override {return QSize(0, 0);}
 };

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -1149,7 +1149,7 @@ QAction* CDockManager::addToggleViewActionToMenu(QAction* ToggleViewAction,
 	bool AlphabeticallySorted = (MenuAlphabeticallySorted == d->MenuInsertionOrder);
 	if (!Group.isEmpty())
 	{
-		QMenu* GroupMenu = d->ViewMenuGroups.value(Group, 0);
+		QMenu* GroupMenu = d->ViewMenuGroups.value(Group, nullptr);
 		if (!GroupMenu)
 		{
 			GroupMenu = new QMenu(Group, this);

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -566,7 +566,7 @@ CDockContainerWidget* CDockWidget::dockContainer() const
 	}
 	else
 	{
-		return 0;
+		return nullptr;
 	}
 }
 

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -256,7 +256,7 @@ public:
      * by calling setObjectName() after construction.
      * Use the layoutFlags to configure the layout of the dock widget.
      */
-    CDockWidget(const QString &title, QWidget* parent = 0);
+    CDockWidget(const QString &title, QWidget* parent = nullptr);
 
     /**
      * Virtual Destructor

--- a/src/DockWidgetTab.h
+++ b/src/DockWidgetTab.h
@@ -84,7 +84,7 @@ public:
 	 * param[in] DockWidget The dock widget this title bar belongs to
 	 * param[in] parent The parent widget of this title bar
 	 */
-	CDockWidgetTab(CDockWidget* DockWidget, QWidget* parent = 0);
+	CDockWidgetTab(CDockWidget* DockWidget, QWidget* parent = nullptr);
 
 	/**
 	 * Virtual Destructor

--- a/src/ElidingLabel.h
+++ b/src/ElidingLabel.h
@@ -58,8 +58,8 @@ protected:
 public:
     using Super = QLabel;
 
-    CElidingLabel(QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags ());
-    CElidingLabel(const QString& text, QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags ());
+    CElidingLabel(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags ());
+    CElidingLabel(const QString& text, QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags ());
 	virtual ~CElidingLabel();
 
 	/**

--- a/src/ads_globals.cpp
+++ b/src/ads_globals.cpp
@@ -92,7 +92,7 @@ xcb_atom_t xcb_get_atom(const char *name)
 	}
 	xcb_connection_t *connection = x11_connection();
 	xcb_intern_atom_cookie_t request = xcb_intern_atom(connection, 1, strlen(name), name);
-	xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(connection, request, NULL);
+	xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(connection, request, nullptr);
 	if (!reply)
 	{
 		return XCB_ATOM_NONE;

--- a/src/linux/FloatingWidgetTitleBar.cpp
+++ b/src/linux/FloatingWidgetTitleBar.cpp
@@ -137,11 +137,11 @@ CFloatingWidgetTitleBar::CFloatingWidgetTitleBar(CFloatingDockContainer *parent)
 	d->FloatingWidget = parent;
 	d->createLayout();
 
-    auto normalPixmap = this->style()->standardPixmap(QStyle::SP_TitleBarNormalButton, 0, d->MaximizeButton);
+    auto normalPixmap = this->style()->standardPixmap(QStyle::SP_TitleBarNormalButton, nullptr, d->MaximizeButton);
     d->NormalIcon.addPixmap(normalPixmap, QIcon::Normal);
     d->NormalIcon.addPixmap(internal::createTransparentPixmap(normalPixmap, 0.25), QIcon::Disabled);
 
-    auto maxPixmap = this->style()->standardPixmap(QStyle::SP_TitleBarMaxButton, 0, d->MaximizeButton);
+    auto maxPixmap = this->style()->standardPixmap(QStyle::SP_TitleBarMaxButton, nullptr, d->MaximizeButton);
     d->MaximizeIcon.addPixmap(maxPixmap, QIcon::Normal);
     d->MaximizeIcon.addPixmap(internal::createTransparentPixmap(maxPixmap, 0.25), QIcon::Disabled);
     setMaximizedIcon(d->Maximized);


### PR DESCRIPTION
Avoid compiler warnings by using nullptr consistently.