### PR TITLE
fix forward declarations of `QXmlStreamWriter`

### DIFF
--- a/src/AutoHideDockContainer.h
+++ b/src/AutoHideDockContainer.h
@@ -34,7 +34,7 @@
 #include <QSplitter>
 #include "AutoHideTab.h"
 
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ads
 {

--- a/src/AutoHideSideBar.h
+++ b/src/AutoHideSideBar.h
@@ -33,7 +33,7 @@
 #include "ads_globals.h"
 #include "AutoHideTab.h"
 
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ads
 {


### PR DESCRIPTION
This PR fixes the forward declarations for `QXmlStreamWriter`. 