### PR TITLE
Fix ODR violations when using CMake unity builds.

### DIFF
--- a/src/AutoHideTab.cpp
+++ b/src/AutoHideTab.cpp
@@ -44,7 +44,6 @@
 
 namespace ads
 {
-static const char* const LocationProperty = "Location";
 
 /**
  * Private data class of CDockWidgetTab class (pimpl)
@@ -102,7 +101,7 @@ struct AutoHideTabPrivate
 		QMenu* Menu)
 	{
 		auto Action = Menu->addAction(Title);
-		Action->setProperty("Location", Location);
+		Action->setProperty(internal::LocationProperty, Location);
 		QObject::connect(Action, &QAction::triggered, _this, &CAutoHideTab::onAutoHideToActionClicked);
 		Action->setEnabled(Location != _this->sideBarLocation());
 		return Action;
@@ -419,7 +418,7 @@ void CAutoHideTab::unpinDockWidget()
 //===========================================================================
 void CAutoHideTab::onAutoHideToActionClicked()
 {
-	int Location = sender()->property(LocationProperty).toInt();
+	int Location = sender()->property(internal::LocationProperty).toInt();
 	d->DockWidget->setAutoHide(true, (SideBarLocation)Location);
 }
 

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -60,7 +60,6 @@
 
 namespace ads
 {
-static const char* const LocationProperty = "Location";
 
 /**
  * Private data class of CDockAreaTitleBar class (pimpl)
@@ -159,7 +158,7 @@ struct DockAreaTitleBarPrivate
 		QMenu* Menu)
 	{
 		auto Action = Menu->addAction(Title);
-		Action->setProperty("Location", Location);
+		Action->setProperty(internal::LocationProperty, Location);
 		QObject::connect(Action, &QAction::triggered, _this, &CDockAreaTitleBar::onAutoHideToActionClicked);
 		return Action;
 	}
@@ -569,7 +568,7 @@ void CDockAreaTitleBar::onAutoHideDockAreaActionClicked()
 //============================================================================
 void CDockAreaTitleBar::onAutoHideToActionClicked()
 {
-	int Location = sender()->property(LocationProperty).toInt();
+	int Location = sender()->property(internal::LocationProperty).toInt();
 	d->DockArea->toggleAutoHide((SideBarLocation)Location);
 }
 

--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -56,7 +56,6 @@
 
 namespace ads
 {
-static const char* const LocationProperty = "Location";
 using tTabLabel = CElidingLabel;
 
 /**
@@ -225,7 +224,7 @@ struct DockWidgetTabPrivate
 		QMenu* Menu)
 	{
 		auto Action = Menu->addAction(Title);
-		Action->setProperty("Location", Location);
+		Action->setProperty(internal::LocationProperty, Location);
 		QObject::connect(Action, &QAction::triggered, _this, &CDockWidgetTab::onAutoHideToActionClicked);
 		return Action;
 	}
@@ -764,7 +763,7 @@ void CDockWidgetTab::autoHideDockWidget()
 //===========================================================================
 void CDockWidgetTab::onAutoHideToActionClicked()
 {
-	int Location = sender()->property(LocationProperty).toInt();
+	int Location = sender()->property(internal::LocationProperty).toInt();
 	d->DockWidget->toggleAutoHide((SideBarLocation)Location);
 }
 

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -357,7 +357,7 @@ static const char* windowsMessageString(int MessageId)
 #endif
 
 
-static unsigned int zOrderCounter = 0;
+static unsigned int zOrderCounterFloating = 0;
 /**
  * Private data class of CFloatingDockContainer class (pimpl)
  */
@@ -365,7 +365,7 @@ struct FloatingDockContainerPrivate
 {
 	CFloatingDockContainer *_this;
 	CDockContainerWidget *DockContainer;
-	unsigned int zOrderIndex = ++zOrderCounter;
+	unsigned int zOrderIndex = ++zOrderCounterFloating;
 	QPointer<CDockManager> DockManager;
 	eDragState DraggingState = DraggingInactive;
 	QPoint DragStartMousePosition;
@@ -818,7 +818,7 @@ void CFloatingDockContainer::changeEvent(QEvent *event)
 		if (isActiveWindow())
 		{
 			ADS_PRINT("FloatingWidget::changeEvent QEvent::ActivationChange ");
-			d->zOrderIndex = ++zOrderCounter;
+			d->zOrderIndex = ++zOrderCounterFloating;
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
 			if (d->DraggingState == DraggingFloatingWidget)

--- a/src/ads_globals.h
+++ b/src/ads_globals.h
@@ -167,6 +167,7 @@ static const bool RestoreTesting = true;
 static const bool Restore = false;
 static const char* const ClosedProperty = "close";
 static const char* const DirtyProperty = "dirty";
+static const char* const LocationProperty = "Location";
 extern const int FloatingWidgetDragStartEvent;
 extern const int DockedWidgetDragStartEvent;
 


### PR DESCRIPTION
I like to build my projects with `CMAKE_UNITY_BUILD` enabled. However, a few ODR vialations prevent a unity build.

I changed the following things:

* move the `LocationProperty` to the `ads_globals.h` header
* use the `LocationProperty` for all `"Location"` strings
* rename `zOrderCounter` in `FloatingDockContainer.cpp`  to `zOrderCounterFloating`