### PR TITLE
Check if pointers used in singleShot timer are still valid

### DIFF
--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -111,8 +111,9 @@ void DockAreaTabBarPrivate::updateTabs()
 			// Sometimes the synchronous calculation of the rectangular area fails
 			// Therefore we use QTimer::singleShot here to execute the call
 			// within the event loop - see #520
-			QTimer::singleShot(0, [&, TabWidget]{
-			    _this->ensureWidgetVisible(TabWidget);
+			QTimer::singleShot(0, TabWidget, [&, TabWidget]
+			{
+				_this->ensureWidgetVisible(TabWidget);
 			});
 		}
 		else


### PR DESCRIPTION
In some situation the singleShot timer crashes because of already deleted objects. A check of the pointers fixes that.