### PR TITLE
Include GNUInstallDirs for CMAKE_INSTALL_* vars to be defined

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(QtAdvancedDockingSystem LANGUAGES CXX VERSION ${VERSION_SHORT})
+include(GNUInstallDirs)
 if (${QT_VERSION_MAJOR})
   message(STATUS "Forced to use Qt version ${QT_VERSION_MAJOR}")
   find_package(QT NAMES Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)


### PR DESCRIPTION
For `CMAKE_INSTALL_*` variables introduced by #593 to be defined, CNUInstallDirs has to be included: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#module:GNUInstallDirs