### PR TITLE
Update DockAreaTabBar.cpp

### DIFF
--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -111,7 +111,7 @@ void DockAreaTabBarPrivate::updateTabs()
 			// Sometimes the synchronous calculation of the rectangular area fails
 			// Therefore we use QTimer::singleShot here to execute the call
 			// within the event loop - see #520
-			QTimer::singleShot(0, TabWidget, [&, TabWidget]
+			QTimer::singleShot(0, _this, [&, TabWidget]
 			{
 				_this->ensureWidgetVisible(TabWidget);
 			});


### PR DESCRIPTION
This fix seems to have introduced a regression when _this is deleted before the lambda slot occurred, for example deleting the DockManager (and consequently _this) immediately after the execution of updateTabs function (we encountered this problem in linux)