### PR TITLE
Make CFloatingDockContainer::startDragging public

### DIFF
--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -132,15 +132,6 @@ protected:
         eDragState DragState, QWidget* MouseEventHandler) override;
 
 	/**
-	 * Call this function to start dragging the floating widget
-	 */
-    void startDragging(const QPoint& DragStartMousePos, const QSize& Size,
-        QWidget* MouseEventHandler)
-	{
-        startFloating(DragStartMousePos, Size, DraggingFloatingWidget, MouseEventHandler);
-	}
-
-	/**
 	 * Call this function if you explicitly want to signal that dragging has
 	 * finished
 	 */
@@ -235,6 +226,15 @@ public:
 	 * Access function for the internal dock container
 	 */
 	CDockContainerWidget* dockContainer() const;
+
+	/**
+	 * Call this function to start dragging the floating widget
+	 */
+    void startDragging(const QPoint& DragStartMousePos, const QSize& Size,
+        QWidget* MouseEventHandler)
+	{
+        startFloating(DragStartMousePos, Size, DraggingFloatingWidget, MouseEventHandler);
+	}
 
 	/**
 	 * This function returns true, if it can be closed.


### PR DESCRIPTION
Expose CFloatingDockContainer::startDragging as a public method to allow external code to initiate the dragging of floating dock containers. This enables users to programmatically initiate view drags, even from non-ADS widgets.