### PR TITLE
Fixed: the focusable CDockWidget would lose focus when another QWindow containing a CDockManager that contains a focusable CDockWidget gains focus

### DIFF
--- a/src/DockFocusController.cpp
+++ b/src/DockFocusController.cpp
@@ -260,7 +260,8 @@ void CDockFocusController::onFocusWindowChanged(QWindow *focusWindow)
 		return;
 	}
 
-	d->updateDockWidgetFocus(DockWidget);
+    if(DockWidget->dockManager() == d->DockManager)
+        d->updateDockWidgetFocus(DockWidget);
 }
 
 
@@ -298,10 +299,11 @@ void CDockFocusController::onApplicationFocusChanged(QWidget* focusedOld, QWidge
     if (!DockWidget || DockWidget->tabWidget()->isHidden())
 	{
     	return;
-	}
+    }
 #endif
 
-	d->updateDockWidgetFocus(DockWidget);
+    if(DockWidget->dockManager() == d->DockManager)
+        d->updateDockWidgetFocus(DockWidget);
 }
 
 
@@ -309,7 +311,7 @@ void CDockFocusController::onApplicationFocusChanged(QWidget* focusedOld, QWidge
 void CDockFocusController::setDockWidgetTabFocused(CDockWidgetTab* Tab)
 {
 	auto DockWidget = Tab->dockWidget();
-	if (DockWidget)
+    if (DockWidget && DockWidget->dockManager() == d->DockManager)
 	{
 		d->updateDockWidgetFocus(DockWidget);
 	}
@@ -327,7 +329,8 @@ void CDockFocusController::clearDockWidgetFocus(CDockWidget* dockWidget)
 //===========================================================================
 void CDockFocusController::setDockWidgetFocused(CDockWidget* focusedNow)
 {
-	d->updateDockWidgetFocus(focusedNow);
+    if(focusedNow->dockManager() == d->DockManager)
+        d->updateDockWidgetFocus(focusedNow);
 }
 
 


### PR DESCRIPTION
This bug occurs when one application contains more than one CDockManager. Bug fix as the title says, the demo image as follows:

> note the TAB COLOR CHANGE (the focused tab have top and right boder with light blue color)

before:

https://github.com/user-attachments/assets/5f9cdb31-be3d-4852-a54f-036edd4bb579

after:

https://github.com/user-attachments/assets/e523b7f2-b492-416e-a45c-366c6e00d306

