### PR TITLE
Customizable Context Menu and multiple Factories in docker manager

### DIFF
--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -75,18 +75,17 @@
 #endif
 #endif
 
-#include "DockManager.h"
-#include "DockWidget.h"
-#include "DockAreaWidget.h"
-#include "DockAreaTitleBar.h"
 #include "DockAreaTabBar.h"
-#include "FloatingDockContainer.h"
+#include "DockAreaTitleBar.h"
+#include "DockAreaWidget.h"
 #include "DockComponentsFactory.h"
-#include "StatusDialog.h"
+#include "DockManager.h"
 #include "DockSplitter.h"
+#include "DockWidget.h"
+#include "FloatingDockContainer.h"
 #include "ImageViewer.h"
-
-
+#include "MyDockAreaTitleBar.h"
+#include "StatusDialog.h"
 
 /**
  * Returns a random number from 0 to highest - 1
@@ -147,7 +146,7 @@ public:
 	using Super = ads::CDockComponentsFactory;
 	ads::CDockAreaTitleBar* createDockAreaTitleBar(ads::CDockAreaWidget* DockArea) const override
 	{
-		auto TitleBar = new ads::CDockAreaTitleBar(DockArea);
+		auto TitleBar = new MyDockAreaTitleBar(DockArea);
 		auto CustomButton = new QToolButton(DockArea);
 		CustomButton->setToolTip(QObject::tr("Help"));
 		CustomButton->setIcon(svgIcon(":/adsdemo/images/help_outline.svg"));

--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -237,7 +237,7 @@ struct MainWindowPrivate
 		m->setRootPath(QDir::currentPath());
 		w->setModel(m);
 		w->setRootIndex(m->index(QDir::currentPath()));
-		ads::CDockWidget* DockWidget = new ads::CDockWidget(QString("Filesystem %1")
+		ads::CDockWidget* DockWidget = DockManager->createDockWidget(QString("Filesystem %1")
 			.arg(FileSystemCount++));
 		DockWidget->setWidget(w);
 		DockWidget->setIcon(svgIcon(":/adsdemo/images/folder_open.svg"));
@@ -258,7 +258,7 @@ struct MainWindowPrivate
 	{
 		static int CalendarCount = 0;
 		QCalendarWidget* w = new QCalendarWidget();
-		ads::CDockWidget* DockWidget = new ads::CDockWidget(QString("Calendar %1").arg(CalendarCount++));
+		ads::CDockWidget* DockWidget = DockManager->createDockWidget(QString("Calendar %1").arg(CalendarCount++));
 		// The following lines are for testing the setWidget() and takeWidget()
 		// functionality
 		DockWidget->setWidget(w);
@@ -303,7 +303,7 @@ struct MainWindowPrivate
 			.arg(LabelCount)
 			.arg(QTime::currentTime().toString("hh:mm:ss:zzz")));
 
-		ads::CDockWidget* DockWidget = new ads::CDockWidget(QString("Label %1").arg(LabelCount++));
+		ads::CDockWidget* DockWidget = DockManager->createDockWidget(QString("Label %1").arg(LabelCount++));
 		DockWidget->setWidget(l);
 		DockWidget->setIcon(svgIcon(":/adsdemo/images/font_download.svg"));
 		ui.menuView->addAction(DockWidget->toggleViewAction());
@@ -321,7 +321,7 @@ struct MainWindowPrivate
 		w->setPlaceholderText("This is an editor. If you close the editor, it will be "
 			"deleted. Enter your text here.");
 		w->setStyleSheet("border: none");
-		ads::CDockWidget* DockWidget = new ads::CDockWidget(QString("Editor %1").arg(EditorCount++));
+		ads::CDockWidget* DockWidget = DockManager->createDockWidget(QString("Editor %1").arg(EditorCount++));
 		DockWidget->setWidget(w);
 		DockWidget->setIcon(svgIcon(":/adsdemo/images/edit.svg"));
 		DockWidget->setFeature(ads::CDockWidget::CustomCloseHandling, true);
@@ -364,7 +364,7 @@ struct MainWindowPrivate
 
 		auto Result = w->loadFile(FileName);
 		qDebug() << "loadFile result: " << Result;
-		ads::CDockWidget* DockWidget = new ads::CDockWidget(QString("Image Viewer %1").arg(ImageViewerCount++));
+		ads::CDockWidget* DockWidget = DockManager->createDockWidget(QString("Image Viewer %1").arg(ImageViewerCount++));
 		DockWidget->setIcon(svgIcon(":/adsdemo/images/photo.svg"));
 		DockWidget->setWidget(w,ads:: CDockWidget::ForceNoScrollArea);
 		auto ToolBar = DockWidget->createDefaultToolBar();
@@ -379,7 +379,7 @@ struct MainWindowPrivate
 	{
 		static int TableCount = 0;
 		auto w = new CMinSizeTableWidget();
-		ads::CDockWidget* DockWidget = new ads::CDockWidget(QString("Table %1").arg(TableCount++));
+		ads::CDockWidget* DockWidget = DockManager->createDockWidget(QString("Table %1").arg(TableCount++));
 		static int colCount = 5;
 		static int rowCount = 30;
 		w->setColumnCount(colCount);
@@ -418,7 +418,7 @@ struct MainWindowPrivate
 	ads::CDockWidget *createQQuickWidget()
 	{
 		QQuickWidget *widget = new QQuickWidget();
-		ads::CDockWidget *dockWidget = new ads::CDockWidget("Quick");
+		ads::CDockWidget *dockWidget = DockManager->createDockWidget("Quick");
 		dockWidget->setWidget(widget);
 		return dockWidget;
 	}
@@ -433,7 +433,7 @@ struct MainWindowPrivate
 	{
 	   static int ActiveXCount = 0;
 	   QAxWidget* w = new QAxWidget("{6bf52a52-394a-11d3-b153-00c04f79faa6}", parent);
-	   ads::CDockWidget* DockWidget = new ads::CDockWidget(QString("Active X %1").arg(ActiveXCount++));
+	   ads::CDockWidget* DockWidget = DockManager->createDockWidget(QString("Active X %1").arg(ActiveXCount++));
 	   DockWidget->setWidget(w);
 	   ui.menuView->addAction(DockWidget->toggleViewAction());
 	   return DockWidget;

--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -471,12 +471,12 @@ void MainWindowPrivate::createContent()
 	appendFeaturStringToWindowTitle(FileSystemWidget);
 
 	// Test custom factory - we inject a help button into the title bar
-	ads::CDockComponentsFactory::setFactory(new CCustomComponentsFactory());
+    DockManager->setComponentsFactory(new CCustomComponentsFactory());
 	auto TopDockArea = DockManager->addDockWidget(ads::TopDockWidgetArea, FileSystemWidget);
 	// Uncomment the next line if you would like to test the
 	// HideSingleWidgetTitleBar functionality
 	// TopDockArea->setDockAreaFlag(ads::CDockAreaWidget::HideSingleWidgetTitleBar, true);
-	ads::CDockComponentsFactory::resetDefaultFactory();
+	DockManager->setComponentsFactory(ads::CDockComponentsFactory::defaultFactory());
 
 	// We create a calendar widget and clear all flags to prevent the dock area
 	// from closing

--- a/demo/MyDockAreaTitleBar.h
+++ b/demo/MyDockAreaTitleBar.h
@@ -1,0 +1,34 @@
+//
+// Created by fuga on 08 nov 2024.
+//
+
+#ifndef QTADS_MYDOCKAREATITLEBAR_H
+#define QTADS_MYDOCKAREATITLEBAR_H
+
+#include <DockAreaTitleBar.h>
+
+class MyDockAreaTitleBar : public ads::CDockAreaTitleBar {
+public:
+    explicit MyDockAreaTitleBar(ads::CDockAreaWidget* parent)
+        : CDockAreaTitleBar(parent)
+    {}
+
+    QMenu* buildContextMenu(QMenu*) override
+    {
+        auto menu = ads::CDockAreaTitleBar::buildContextMenu(nullptr);
+        menu->addSeparator();
+        auto action = menu->addAction(tr("Format HardDrive"));
+        
+        connect(action, &QAction::triggered, this, [this](){
+            QMessageBox msgBox;
+            msgBox.setText("No, just kidding");
+            msgBox.setStandardButtons(QMessageBox::Abort);
+            msgBox.setDefaultButton(QMessageBox::Abort);
+            msgBox.exec();
+        });
+        
+        return menu;
+    }
+};
+
+#endif  // QTADS_MYDOCKAREATITLEBAR_H

--- a/src/AutoHideDockContainer.cpp
+++ b/src/AutoHideDockContainer.cpp
@@ -109,6 +109,7 @@ int resizeHandleLayoutPosition(SideBarLocation Area)
  */
 struct AutoHideDockContainerPrivate
 {
+    CDockManager *DockManager;
     CAutoHideDockContainer* _this;
 	CDockAreaWidget* DockArea{nullptr};
 	CDockWidget* DockWidget{nullptr};
@@ -122,7 +123,11 @@ struct AutoHideDockContainerPrivate
 	/**
 	 * Private data constructor
 	 */
-	AutoHideDockContainerPrivate(CAutoHideDockContainer *_public);
+	AutoHideDockContainerPrivate(CDockManager *manager, CAutoHideDockContainer *_public);
+
+    QSharedPointer<ads::CDockComponentsFactory> componentsFactory() const {
+        return DockManager->componentsFactory();
+    }
 
 	/**
 	 * Convenience function to get a dock widget area
@@ -178,8 +183,9 @@ struct AutoHideDockContainerPrivate
 
 //============================================================================
 AutoHideDockContainerPrivate::AutoHideDockContainerPrivate(
+    CDockManager *manager,
     CAutoHideDockContainer *_public) :
-	_this(_public)
+	DockManager(manager), _this(_public)
 {
 
 }
@@ -195,11 +201,11 @@ CDockContainerWidget* CAutoHideDockContainer::dockContainer() const
 //============================================================================
 CAutoHideDockContainer::CAutoHideDockContainer(CDockWidget* DockWidget, SideBarLocation area, CDockContainerWidget* parent) :
 	Super(parent),
-    d(new AutoHideDockContainerPrivate(this))
+    d(new AutoHideDockContainerPrivate(DockWidget->dockManager(), this))
 {
 	hide(); // auto hide dock container is initially always hidden
 	d->SideTabBarArea = area;
-	d->SideTab = componentsFactory()->createDockWidgetSideTab(nullptr);
+	d->SideTab = d->componentsFactory()->createDockWidgetSideTab(nullptr);
 	connect(d->SideTab, &CAutoHideTab::pressed, this, &CAutoHideDockContainer::toggleCollapseState);
 	d->DockArea = new CDockAreaWidget(DockWidget->dockManager(), parent);
 	d->DockArea->setObjectName("autoHideDockArea");

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -770,24 +770,35 @@ void CDockAreaTitleBar::contextMenuEvent(QContextMenuEvent* ev)
 		return;
 	}
 
-	const bool isAutoHide = d->DockArea->isAutoHide();
+    auto Menu = buildContextMenu(nullptr);
+	Menu->exec(ev->globalPos());
+    delete Menu;
+}
+
+QMenu* CDockAreaTitleBar::buildContextMenu(QMenu *Menu)
+{
+    const bool isAutoHide = d->DockArea->isAutoHide();
 	const bool isTopLevelArea = d->DockArea->isTopLevelArea();
 	QAction* Action;
-	QMenu Menu(this);
-	if (!isTopLevelArea)
+    if (Menu == nullptr)
+    {
+        Menu = new QMenu(this);
+    }
+    
+    if (!isTopLevelArea)
 	{
-		Action = Menu.addAction(isAutoHide ? tr("Detach") : tr("Detach Group"),
+		Action = Menu->addAction(isAutoHide ? tr("Detach") : tr("Detach Group"),
 			this, SLOT(onUndockButtonClicked()));
 		Action->setEnabled(d->DockArea->features().testFlag(CDockWidget::DockWidgetFloatable));
 		if (CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideFeatureEnabled))
 		{
-			Action = Menu.addAction(isAutoHide ? tr("Unpin (Dock)") : tr("Pin Group"), this, SLOT(onAutoHideDockAreaActionClicked()));
+			Action = Menu->addAction(isAutoHide ? tr("Unpin (Dock)") : tr("Pin Group"), this, SLOT(onAutoHideDockAreaActionClicked()));
 			auto AreaIsPinnable = d->DockArea->features().testFlag(CDockWidget::DockWidgetPinnable);
 			Action->setEnabled(AreaIsPinnable);
 
 			if (!isAutoHide)
 			{
-				auto menu = Menu.addMenu(tr("Pin Group To..."));
+				auto menu = Menu->addMenu(tr("Pin Group To..."));
 				menu->setEnabled(AreaIsPinnable);
 				d->createAutoHideToAction(tr("Top"), SideBarTop, menu);
 				d->createAutoHideToAction(tr("Left"), SideBarLeft, menu);
@@ -795,27 +806,26 @@ void CDockAreaTitleBar::contextMenuEvent(QContextMenuEvent* ev)
 				d->createAutoHideToAction(tr("Bottom"), SideBarBottom, menu);
 			}
 		}
-		Menu.addSeparator();
+		Menu->addSeparator();
 	}
 
 	if (isAutoHide)
 	{
-		Action = Menu.addAction(tr("Minimize"), this, SLOT(minimizeAutoHideContainer()));
-		Action = Menu.addAction(tr("Close"), this, SLOT(onAutoHideCloseActionTriggered()));
+		Action = Menu->addAction(tr("Minimize"), this, SLOT(minimizeAutoHideContainer()));
+		Action = Menu->addAction(tr("Close"), this, SLOT(onAutoHideCloseActionTriggered()));
 	}
 	else
 	{
-		Action = Menu.addAction(isAutoHide ? tr("Close") : tr("Close Group"), this, SLOT(onCloseButtonClicked()));
+		Action = Menu->addAction(isAutoHide ? tr("Close") : tr("Close Group"), this, SLOT(onCloseButtonClicked()));
 	}
 
 	Action->setEnabled(d->DockArea->features().testFlag(CDockWidget::DockWidgetClosable));
 	if (!isAutoHide && !isTopLevelArea)
 	{
-		Action = Menu.addAction(tr("Close Other Groups"), d->DockArea, SLOT(closeOtherAreas()));
+		Action = Menu->addAction(tr("Close Other Groups"), d->DockArea, SLOT(closeOtherAreas()));
 	}
-	Menu.exec(ev->globalPos());
+    return Menu;
 }
-
 
 //============================================================================
 void CDockAreaTitleBar::insertWidget(int index, QWidget *widget)

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -66,6 +66,7 @@ namespace ads
  */
 struct DockAreaTitleBarPrivate
 {
+    CDockManager *DockManager;
 	CDockAreaTitleBar* _this;
 	QPointer<CTitleBarButton> TabsMenuButton;
 	QPointer<CTitleBarButton> AutoHideButton;
@@ -88,7 +89,11 @@ struct DockAreaTitleBarPrivate
 	/**
 	 * Private data constructor
 	 */
-	DockAreaTitleBarPrivate(CDockAreaTitleBar* _public);
+	DockAreaTitleBarPrivate(CDockManager *manager, CDockAreaTitleBar* _public);
+
+    QSharedPointer<ads::CDockComponentsFactory> componentsFactory() const {
+        return DockManager->componentsFactory();
+    }
 
 	/**
 	 * Creates the title bar close and menu buttons
@@ -165,8 +170,8 @@ struct DockAreaTitleBarPrivate
 };// struct DockAreaTitleBarPrivate
 
 //============================================================================
-DockAreaTitleBarPrivate::DockAreaTitleBarPrivate(CDockAreaTitleBar* _public) :
-	_this(_public)
+DockAreaTitleBarPrivate::DockAreaTitleBarPrivate(CDockManager *manager, CDockAreaTitleBar* _public) :
+	DockManager(manager), _this(_public)
 {
 
 }
@@ -331,7 +336,7 @@ void DockAreaTitleBarPrivate::startFloating(const QPoint& Offset)
 //============================================================================
 CDockAreaTitleBar::CDockAreaTitleBar(CDockAreaWidget* parent) :
 	QFrame(parent),
-	d(new DockAreaTitleBarPrivate(this))
+	d(new DockAreaTitleBarPrivate(parent->dockManager(), this))
 {
 	d->DockArea = parent;
 

--- a/src/DockAreaTitleBar.h
+++ b/src/DockAreaTitleBar.h
@@ -249,6 +249,20 @@ public:
 	 */
 	bool isAutoHide() const;
 
+    /**
+     * Fills the provided menu with standard entries. If a nullptr is passed, a
+     * new menu is created and filled with standard entries.
+     * This function is called from the actual version of contextMenuEvent, but
+     * can be called from any code. Caller is responsible of deleting the created
+     * object.
+     *
+     * @param menu The QMenu to fill with standard entries. If nullptr, a new
+     * QMenu will be created.
+     * @return The filled QMenu, either the provided one or a newly created one if
+     * nullptr was passed.
+     */
+    virtual QMenu *buildContextMenu(QMenu *);
+
 Q_SIGNALS:
 	/**
 	 * This signal is emitted if a tab in the tab bar is clicked by the user

--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -264,6 +264,10 @@ struct DockAreaWidgetPrivate
 	QSize MinSizeHint;
 	CDockAreaWidget::DockAreaFlags Flags{CDockAreaWidget::DefaultFlags};
 
+    QSharedPointer<ads::CDockComponentsFactory> componentsFactory() const {
+        return DockManager->componentsFactory();
+    }
+
 	/**
 	 * Private data constructor
 	 */

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -38,6 +38,7 @@
 
 QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 QT_FORWARD_DECLARE_CLASS(QAbstractButton)
+QT_FORWARD_DECLARE_CLASS(QMenu)
 
 namespace ads
 {

--- a/src/DockComponentsFactory.cpp
+++ b/src/DockComponentsFactory.cpp
@@ -21,7 +21,8 @@
 
 namespace ads
 {
-static std::unique_ptr<CDockComponentsFactory> DefaultFactory(new CDockComponentsFactory());
+
+static QSharedPointer<ads::CDockComponentsFactory> DefaultFactory;
 
 
 //============================================================================
@@ -50,26 +51,15 @@ CDockAreaTitleBar* CDockComponentsFactory::createDockAreaTitleBar(CDockAreaWidge
 	return new CDockAreaTitleBar(DockArea);
 }
 
-
-//============================================================================
-const CDockComponentsFactory* CDockComponentsFactory::factory()
+QSharedPointer<ads::CDockComponentsFactory>
+    CDockComponentsFactory::defaultFactory()
 {
-	return DefaultFactory.get();
+    if (!DefaultFactory) {
+        DefaultFactory.reset(new CDockComponentsFactory());
+    }
+    return DefaultFactory;
 }
 
-
-//============================================================================
-void CDockComponentsFactory::setFactory(CDockComponentsFactory* Factory)
-{
-	DefaultFactory.reset(Factory);
-}
-
-
-//============================================================================
-void CDockComponentsFactory::resetDefaultFactory()
-{
-	DefaultFactory.reset(new CDockComponentsFactory());
-}
 } // namespace ads
 
 //---------------------------------------------------------------------------

--- a/src/DockComponentsFactory.h
+++ b/src/DockComponentsFactory.h
@@ -65,31 +65,8 @@ public:
 	 */
 	virtual CDockAreaTitleBar* createDockAreaTitleBar(CDockAreaWidget* DockArea) const;
 
-	/**
-	 * Returns the default components factory
-	 */
-	static const CDockComponentsFactory* factory();
-
-	/**
-	 * Sets a new default factory for creation of GUI elements.
-	 * This function takes ownership of the given Factory.
-	 */
-	static void setFactory(CDockComponentsFactory* Factory);
-
-	/**
-	 * Resets the current factory to the
-	 */
-	static void resetDefaultFactory();
+    static QSharedPointer<ads::CDockComponentsFactory> defaultFactory();
 };
-
-
-/**
- * Convenience function to ease factory instance access
- */
-inline const CDockComponentsFactory* componentsFactory()
-{
-	return CDockComponentsFactory::factory();
-}
 
 } // namespace ads
 

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -1280,6 +1280,10 @@ CIconProvider& CDockManager::iconProvider()
 	return Instance;
 }
 
+CDockWidget* CDockManager::createDockWidget(const QString& title, QWidget* parent)
+{
+    return new CDockWidget(this, title, parent);
+}
 
 //===========================================================================
 void CDockManager::notifyWidgetOrAreaRelocation(QWidget* DroppedWidget)

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -31,6 +31,7 @@
 #include <AutoHideDockContainer.h>
 #include "DockWidgetTab.h"
 #include "DockManager.h"
+#include "DockComponentsFactory.h"
 
 #include <algorithm>
 #include <iostream>
@@ -124,6 +125,8 @@ struct DockManagerPrivate
 	QSize ToolBarIconSizeFloating = QSize(24, 24);
 	CDockWidget::DockWidgetFeatures LockedDockWidgetFeatures;
 
+    QSharedPointer<ads::CDockComponentsFactory> componentFactory {ads::CDockComponentsFactory::defaultFactory()};
+
 	/**
 	 * Private data constructor
 	 */
@@ -190,7 +193,6 @@ struct DockManagerPrivate
 DockManagerPrivate::DockManagerPrivate(CDockManager* _public) :
 	_this(_public)
 {
-
 }
 
 
@@ -577,6 +579,21 @@ CDockManager::~CDockManager()
 	}
 
 	delete d;
+}
+
+ QSharedPointer<ads::CDockComponentsFactory> CDockManager::componentsFactory() const
+{
+    return d->componentFactory;
+}
+
+void CDockManager::setComponentsFactory(ads::CDockComponentsFactory* factory)
+{
+    d->componentFactory = QSharedPointer<ads::CDockComponentsFactory>(factory);
+}
+
+void CDockManager::setComponentsFactory(QSharedPointer<ads::CDockComponentsFactory> factory)
+{
+    d->componentFactory = factory;
 }
 
 //============================================================================

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -277,6 +277,12 @@ public:
 	 */
 	virtual ~CDockManager() override;
 
+    QSharedPointer<ads::CDockComponentsFactory> componentsFactory() const;
+
+    void setComponentsFactory(ads::CDockComponentsFactory *);
+
+    void setComponentsFactory(QSharedPointer<ads::CDockComponentsFactory>);
+
 	/**
 	 * This function returns the global configuration flags
 	 */

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -336,6 +336,21 @@ public:
 	 */
 	static CIconProvider& iconProvider();
 
+    /**
+     * Creates a new dock widget with the specified title and optional parent
+     * widget.
+     *
+     * The new dock widget will be managed by the dock manager, and its lifetime
+     * will be tied to the dock manager. If a parent widget is provided, the dock
+     * widget will be created as a child of the parent widget. If no parent widget
+     * is provided, the dock widget will be created as a top-level widget.
+     *
+     * @param title The title of the dock widget.
+     * @param parent The parent widget, if any. Defaults to nullptr.
+     * @return Returns a pointer to the created CDockWidget.
+     */
+    CDockWidget *createDockWidget(const QString &title, QWidget* parent = nullptr);
+
 	/**
 	 * Adds dockwidget into the given area.
 	 * If DockAreaWidget is not null, then the area parameter indicates the area

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -80,7 +80,7 @@ struct DockWidgetPrivate
 	QWidget* Widget = nullptr;
 	CDockWidgetTab* TabWidget = nullptr;
 	CDockWidget::DockWidgetFeatures Features = CDockWidget::DefaultDockWidgetFeatures;
-	QPointer<CDockManager> DockManager;
+	QPointer<CDockManager> DockManager {nullptr};
 	QPointer<CDockAreaWidget> DockArea;
 	QAction* ToggleViewAction = nullptr;
 	bool Closed = false;
@@ -357,9 +357,9 @@ void DockWidgetPrivate::setToolBarStyleFromDockManager()
 
 
 //============================================================================
-CDockWidget::CDockWidget(const QString &title, QWidget *parent) :
-	QFrame(parent),
-	d(new DockWidgetPrivate(this))
+CDockWidget::CDockWidget(CDockManager* manager, const QString& title,
+                         QWidget* parent)
+: QFrame(parent), d(new DockWidgetPrivate(this))
 {
 	d->Layout = new QBoxLayout(QBoxLayout::TopToBottom);
 	d->Layout->setContentsMargins(0, 0, 0, 0);
@@ -368,7 +368,8 @@ CDockWidget::CDockWidget(const QString &title, QWidget *parent) :
 	setWindowTitle(title);
 	setObjectName(title);
 
-	d->TabWidget = componentsFactory()->createDockWidgetTab(this);
+    auto factory = manager ? manager->componentsFactory() : CDockComponentsFactory::defaultFactory();
+	d->TabWidget = factory->createDockWidgetTab(this);
 
 	d->ToggleViewAction = new QAction(title, this);
 	d->ToggleViewAction->setCheckable(true);
@@ -381,6 +382,10 @@ CDockWidget::CDockWidget(const QString &title, QWidget *parent) :
 		setFocusPolicy(Qt::ClickFocus);
 	}
 }
+
+CDockWidget::CDockWidget(const QString &title, QWidget *parent) :
+      CDockWidget(nullptr, title, parent)
+{}
 
 //============================================================================
 CDockWidget::~CDockWidget()

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -259,6 +259,29 @@ public:
      */
     explicit CDockWidget(const QString &title, QWidget* parent = nullptr);
 
+    /**
+     * This constructor creates a dock widget for the given dock manager with the
+     * provided title.
+     *
+     * @param manager Pointer to the dock manager that owns the dock widget.
+     * @param title The title is the text that is shown in the window title when
+     * the dock widget is floating and it is the title that is shown in the
+     * titlebar or the tab of this dock widget if it is tabified.
+     * @param parent Pointer to the parent widget, defaults to nullptr.
+     *
+     * @note The object name of the dock widget is also set to the title. The
+     * object name is required by the dock manager to properly save and restore
+     * the state of the dock widget. That means, the title needs to be unique. If
+     * the title is not unique or if you would like to change the title during
+     * runtime, you need to set a unique object name explicitly by calling
+     * setObjectName() after construction. Use the layoutFlags to configure the
+     * layout of the dock widget.
+     *
+     * @note this constructor is preferred over the two argument version, especially
+     * when custom factories are in use. Indeed, it will use the Dock Manager factory,
+     * and not the default factory. For this reason, the original constructor should
+     * be deprecated in favour of this version.
+     */
     CDockWidget(CDockManager *manager, const QString &title, QWidget* parent = nullptr);
 
     /**

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -257,7 +257,9 @@ public:
      * by calling setObjectName() after construction.
      * Use the layoutFlags to configure the layout of the dock widget.
      */
-    CDockWidget(const QString &title, QWidget* parent = nullptr);
+    explicit CDockWidget(const QString &title, QWidget* parent = nullptr);
+
+    CDockWidget(CDockManager *manager, const QString &title, QWidget* parent = nullptr);
 
     /**
      * Virtual Destructor

--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -529,26 +529,34 @@ void CDockWidgetTab::contextMenuEvent(QContextMenuEvent* ev)
 		return;
 	}
 
+    auto Menu = buildContextMenu(nullptr);
 	d->saveDragStartMousePosition(ev->globalPos());
+	Menu->exec(ev->globalPos());
+}
 
+QMenu* CDockWidgetTab::buildContextMenu(QMenu *Menu)
+{
+    if (Menu == nullptr) {
+        Menu = new QMenu(this);
+    }
+    
     const bool isFloatable = d->DockWidget->features().testFlag(CDockWidget::DockWidgetFloatable);
     const bool isNotOnlyTabInContainer =  !d->DockArea->dockContainer()->hasTopLevelDockWidget();
     const bool isTopLevelArea = d->DockArea->isTopLevelArea();
     const bool isDetachable = isFloatable && isNotOnlyTabInContainer;
 	QAction* Action;
-	QMenu Menu(this);
 
     if (!isTopLevelArea)
     {
-		Action = Menu.addAction(tr("Detach"), this, SLOT(detachDockWidget()));
+		Action = Menu->addAction(tr("Detach"), this, SLOT(detachDockWidget()));
 		Action->setEnabled(isDetachable);
 		if (CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideFeatureEnabled))
 		{
-			Action = Menu.addAction(tr("Pin"), this, SLOT(autoHideDockWidget()));
+			Action = Menu->addAction(tr("Pin"), this, SLOT(autoHideDockWidget()));
 			auto IsPinnable = d->DockWidget->features().testFlag(CDockWidget::DockWidgetPinnable);
 			Action->setEnabled(IsPinnable);
 
-			auto menu = Menu.addMenu(tr("Pin To..."));
+			auto menu = Menu->addMenu(tr("Pin To..."));
 			menu->setEnabled(IsPinnable);
 			d->createAutoHideToAction(tr("Top"), SideBarTop, menu);
 			d->createAutoHideToAction(tr("Left"), SideBarLeft, menu);
@@ -557,17 +565,16 @@ void CDockWidgetTab::contextMenuEvent(QContextMenuEvent* ev)
 		}
     }
 
-	Menu.addSeparator();
-	Action = Menu.addAction(tr("Close"), this, SIGNAL(closeRequested()));
+	Menu->addSeparator();
+	Action = Menu->addAction(tr("Close"), this, SIGNAL(closeRequested()));
 	Action->setEnabled(isClosable());
 	if (d->DockArea->openDockWidgetsCount() > 1)
 	{
-		Action = Menu.addAction(tr("Close Others"), this, SIGNAL(closeOtherTabsRequested()));
+		Action = Menu->addAction(tr("Close Others"), this, SIGNAL(closeOtherTabsRequested()));
 	}
-	Menu.exec(ev->globalPos());
+
+    return Menu;
 }
-
-
 //============================================================================
 bool CDockWidgetTab::isActiveTab() const
 {

--- a/src/DockWidgetTab.h
+++ b/src/DockWidgetTab.h
@@ -35,6 +35,8 @@
 
 #include "ads_globals.h"
 
+QT_FORWARD_DECLARE_CLASS(QMenu)
+
 namespace ads
 {
 class CDockWidget;

--- a/src/DockWidgetTab.h
+++ b/src/DockWidgetTab.h
@@ -184,6 +184,20 @@ public:
 	 */
 	eDragState dragState() const;
 
+    /**
+     * Fills the provided menu with standard entries. If a nullptr is passed, a
+     * new menu is created and filled with standard entries.
+     * This function is called from the actual version of contextMenuEvent, but
+     * can be called from any code. Caller is responsible of deleting the created
+     * object.
+     *
+     * @param menu The QMenu to fill with standard entries. If nullptr, a new
+     * QMenu will be created.
+     * @return The filled QMenu, either the provided one or a newly created one if
+     * nullptr was passed.
+     */
+    virtual QMenu *buildContextMenu(QMenu *);
+
 public Q_SLOTS:
 	virtual void setVisible(bool visible) override;
 


### PR DESCRIPTION
# Customizable Context Menu and multiple Factories in docker manager

## Description

This pull request introduces two significant enhancements to the ADS repository:

- Customizable Context Menu for Docker Tabs:
The context menu of the tabs within the docker widgets can now be customized.
An example customization includes adding the list of perspectives of the Docker inside the docker widget.

- Support for multiple factories on per manager basis (instead of singleton)
Refactored the Factory to be a subobject of the Docker Manager.
This allows for different components to be created based on the Docker Manager context.
Ensures retrocompatibility by introducing a new constructor for the docker widget to pass the factory.
Added a creator method in the Docker Manager to facilitate component creation instead of direct instantiation.

## Key Changes

Context Menu Customization:
Enabled the addition of custom items to the context menu of docker widget tabs.
The context menu building has been extracted as a virtual function from the context menu handling function, so that any derived class can override it and adds additional items on it before desplaying


Refactoring:
Moved the Factory to be a subobject of the Docker Manager.
Modified the Docker Widget constructor to accept a factory parameter.
Added a creator method in Docker Manager for creating components.

Benefits
Flexibility: Allows for a more flexible and customizable UI experience.
Modularity: Enhances modularity by decoupling the creation logic from direct instantiation.
Retrocompatibility: Maintains compatibility with existing implementations while offering new features.

## Testing

Some example has  been adapted to use the new factory method and functions. In that example, the tab component of the docker has been subclassed to include some additional function in the popup menu.

