### PR TITLE
Improved tab bar scrolling

### DIFF
--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -158,6 +158,12 @@ CDockAreaTabBar::~CDockAreaTabBar()
 
 
 //============================================================================
+void CDockAreaTabBar::wheelEvent(QWheelEvent* Event)
+{
+    QCoreApplication::sendEvent(horizontalScrollBar(), Event);
+}
+
+//============================================================================
 void CDockAreaTabBar::setCurrentIndex(int index)
 {
 	if (index == d->CurrentIndex)

--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -158,22 +158,6 @@ CDockAreaTabBar::~CDockAreaTabBar()
 
 
 //============================================================================
-void CDockAreaTabBar::wheelEvent(QWheelEvent* Event)
-{
-	Event->accept();
-	const int direction = Event->angleDelta().y();
-	if (direction < 0)
-	{
-		horizontalScrollBar()->setValue(horizontalScrollBar()->value() + 20);
-	}
-	else
-	{
-		horizontalScrollBar()->setValue(horizontalScrollBar()->value() - 20);
-	}
-}
-
-
-//============================================================================
 void CDockAreaTabBar::setCurrentIndex(int index)
 {
 	if (index == d->CurrentIndex)
@@ -356,7 +340,7 @@ void CDockAreaTabBar::onCloseOtherTabsRequested()
 				CDockWidget::DockWidgetDeleteOnClose) ? 1 : 0;
 			closeTab(i);
 
-			// If the the dock widget blocks closing, i.e. if the flag
+			// If the dock widget blocks closing, i.e. if the flag
 			// CustomCloseHandling is set, and the dock widget is still open,
 			// then we do not need to correct the index
 			if (Tab->dockWidget()->isClosed())

--- a/src/DockAreaTabBar.h
+++ b/src/DockAreaTabBar.h
@@ -64,10 +64,6 @@ private Q_SLOTS:
 	void onCloseOtherTabsRequested();
 	void onTabWidgetMoved(const QPoint& GlobalPos);
 
-protected:
-	virtual void wheelEvent(QWheelEvent* Event) override;
-
-
 public:
 	using Super = QScrollArea;
 

--- a/src/DockAreaTabBar.h
+++ b/src/DockAreaTabBar.h
@@ -64,6 +64,9 @@ private Q_SLOTS:
 	void onCloseOtherTabsRequested();
 	void onTabWidgetMoved(const QPoint& GlobalPos);
 
+protected:
+    virtual void wheelEvent(QWheelEvent* Event) override;
+
 public:
 	using Super = QScrollArea;
 


### PR DESCRIPTION
Remove custom wheelEvent handler. Default QAbstractScrollArea wheel handler seems to work better on platforms like MacOS.

Before:

https://github.com/user-attachments/assets/04c06c78-b0d3-4790-8b23-a96be8b4aa68

due to hardcoded step value, it is very difficult to scroll to the desired tab

After:

https://github.com/user-attachments/assets/aef90a12-8c10-4451-8e62-7af882ad13d1


