### PR TITLE
Fix issue with windeployqt

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::Co
 if(WIN32 AND QT_VERSION_MAJOR LESS 6)
     target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::AxContainer)
 endif()
-target_link_libraries(AdvancedDockingSystemDemo PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(AdvancedDockingSystemDemo PRIVATE qtadvanceddocking)
 set_target_properties(AdvancedDockingSystemDemo PROPERTIES 
     AUTOMOC ON
     AUTORCC ON

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::Co
 if(WIN32 AND QT_VERSION_MAJOR LESS 6)
     target_link_libraries(AdvancedDockingSystemDemo PUBLIC Qt${QT_VERSION_MAJOR}::AxContainer)
 endif()
-target_link_libraries(AdvancedDockingSystemDemo PRIVATE qtadvanceddocking)
+target_link_libraries(AdvancedDockingSystemDemo PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 set_target_properties(AdvancedDockingSystemDemo PROPERTIES 
     AUTOMOC ON
     AUTORCC ON

--- a/examples/autohide/CMakeLists.txt
+++ b/examples/autohide/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(AutoHideExample WIN32
     mainwindow.ui
 )
 target_include_directories(AutoHideExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(AutoHideExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(AutoHideExample PRIVATE qtadvanceddocking)
 target_link_libraries(AutoHideExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/autohide/CMakeLists.txt
+++ b/examples/autohide/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(AutoHideExample WIN32
     mainwindow.ui
 )
 target_include_directories(AutoHideExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(AutoHideExample PRIVATE qtadvanceddocking)
+target_link_libraries(AutoHideExample PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(AutoHideExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/autohidedragndrop/CMakeLists.txt
+++ b/examples/autohidedragndrop/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(AutoHideDragNDropExample WIN32
     droppableitem.cpp
 )
 target_include_directories(AutoHideDragNDropExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(AutoHideDragNDropExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(AutoHideDragNDropExample PRIVATE qtadvanceddocking)
 target_link_libraries(AutoHideDragNDropExample PUBLIC Qt${QT_VERSION_MAJOR}::Core
                                                   Qt${QT_VERSION_MAJOR}::Gui
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/autohidedragndrop/CMakeLists.txt
+++ b/examples/autohidedragndrop/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(AutoHideDragNDropExample WIN32
     droppableitem.cpp
 )
 target_include_directories(AutoHideDragNDropExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(AutoHideDragNDropExample PRIVATE qtadvanceddocking)
+target_link_libraries(AutoHideDragNDropExample PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(AutoHideDragNDropExample PUBLIC Qt${QT_VERSION_MAJOR}::Core
                                                   Qt${QT_VERSION_MAJOR}::Gui
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/centralwidget/CMakeLists.txt
+++ b/examples/centralwidget/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(CentralWidgetExample WIN32
     mainwindow.ui
 )
 target_include_directories(CentralWidgetExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(CentralWidgetExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(CentralWidgetExample PRIVATE qtadvanceddocking)
 target_link_libraries(CentralWidgetExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/centralwidget/CMakeLists.txt
+++ b/examples/centralwidget/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(CentralWidgetExample WIN32
     mainwindow.ui
 )
 target_include_directories(CentralWidgetExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(CentralWidgetExample PRIVATE qtadvanceddocking)
+target_link_libraries(CentralWidgetExample PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(CentralWidgetExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/configflags/CMakeLists.txt
+++ b/examples/configflags/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(configFlagsExample WIN32
     mainwindow.ui
 )
 target_include_directories(CentralWidgetExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(CentralWidgetExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(CentralWidgetExample PRIVATE qtadvanceddocking)
 target_link_libraries(CentralWidgetExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/configflags/CMakeLists.txt
+++ b/examples/configflags/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(configFlagsExample WIN32
     mainwindow.ui
 )
 target_include_directories(CentralWidgetExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(CentralWidgetExample PRIVATE qtadvanceddocking)
+target_link_libraries(CentralWidgetExample PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(CentralWidgetExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/deleteonclose/CMakeLists.txt
+++ b/examples/deleteonclose/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(DeleteOnCloseTest WIN32
     main.cpp
 )
 target_include_directories(DeleteOnCloseTest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(DeleteOnCloseTest PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(DeleteOnCloseTest PRIVATE qtadvanceddocking)
 target_link_libraries(DeleteOnCloseTest PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/deleteonclose/CMakeLists.txt
+++ b/examples/deleteonclose/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(DeleteOnCloseTest WIN32
     main.cpp
 )
 target_include_directories(DeleteOnCloseTest PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(DeleteOnCloseTest PRIVATE qtadvanceddocking)
+target_link_libraries(DeleteOnCloseTest PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(DeleteOnCloseTest PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/dockindock/CMakeLists.txt
+++ b/examples/dockindock/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(DockInDockExample WIN32
     mainframe.cpp
 )
 target_include_directories(DockInDockExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(DockInDockExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(DockInDockExample PRIVATE qtadvanceddocking)
 target_link_libraries(DockInDockExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                            Qt${QT_VERSION_MAJOR}::Gui 
                                            Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/dockindock/CMakeLists.txt
+++ b/examples/dockindock/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(DockInDockExample WIN32
     mainframe.cpp
 )
 target_include_directories(DockInDockExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(DockInDockExample PRIVATE qtadvanceddocking)
+target_link_libraries(DockInDockExample PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(DockInDockExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                            Qt${QT_VERSION_MAJOR}::Gui 
                                            Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/emptydockarea/CMakeLists.txt
+++ b/examples/emptydockarea/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(EmptyDockAreaExample WIN32
     mainwindow.ui
 )
 target_include_directories(EmptyDockAreaExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(EmptyDockAreaExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(EmptyDockAreaExample PRIVATE qtadvanceddocking)
 target_link_libraries(EmptyDockAreaExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/emptydockarea/CMakeLists.txt
+++ b/examples/emptydockarea/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(EmptyDockAreaExample WIN32
     mainwindow.ui
 )
 target_include_directories(EmptyDockAreaExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(EmptyDockAreaExample PRIVATE qtadvanceddocking)
+target_link_libraries(EmptyDockAreaExample PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(EmptyDockAreaExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                   Qt${QT_VERSION_MAJOR}::Gui 
                                                   Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/hideshow/CMakeLists.txt
+++ b/examples/hideshow/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(HideShowExample WIN32
     MainWindow.ui
 )
 target_include_directories(HideShowExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(HideShowExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(HideShowExample PRIVATE qtadvanceddocking)
 target_link_libraries(HideShowExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                              Qt${QT_VERSION_MAJOR}::Gui 
                                              Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/hideshow/CMakeLists.txt
+++ b/examples/hideshow/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(HideShowExample WIN32
     MainWindow.ui
 )
 target_include_directories(HideShowExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(HideShowExample PRIVATE qtadvanceddocking)
+target_link_libraries(HideShowExample PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(HideShowExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                              Qt${QT_VERSION_MAJOR}::Gui 
                                              Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/sidebar/CMakeLists.txt
+++ b/examples/sidebar/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(SidebarExample WIN32
     MainWindow.ui
 )
 target_include_directories(SidebarExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(SidebarExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(SidebarExample PRIVATE qtadvanceddocking)
 target_link_libraries(SidebarExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                             Qt${QT_VERSION_MAJOR}::Gui 
                                             Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/sidebar/CMakeLists.txt
+++ b/examples/sidebar/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(SidebarExample WIN32
     MainWindow.ui
 )
 target_include_directories(SidebarExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(SidebarExample PRIVATE qtadvanceddocking)
+target_link_libraries(SidebarExample PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(SidebarExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                             Qt${QT_VERSION_MAJOR}::Gui 
                                             Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(SimpleExample WIN32
     MainWindow.ui
 )
 target_include_directories(SimpleExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(SimpleExample PRIVATE qt${QT_VERSION_MAJOR}advanceddocking)
+target_link_libraries(SimpleExample PRIVATE qtadvanceddocking)
 target_link_libraries(SimpleExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                            Qt${QT_VERSION_MAJOR}::Gui 
                                            Qt${QT_VERSION_MAJOR}::Widgets)

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(SimpleExample WIN32
     MainWindow.ui
 )
 target_include_directories(SimpleExample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-target_link_libraries(SimpleExample PRIVATE qtadvanceddocking)
+target_link_libraries(SimpleExample PRIVATE qtadvanceddocking-qt${QT_VERSION_MAJOR})
 target_link_libraries(SimpleExample PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                            Qt${QT_VERSION_MAJOR}::Gui 
                                            Qt${QT_VERSION_MAJOR}::Widgets)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ if (UNIX AND NOT APPLE)
     set(ads_HEADERS linux/FloatingWidgetTitleBar.h ${ads_HEADERS})
 endif()
 
-set(library_name "qt${QT_VERSION_MAJOR}advanceddocking")
+set(library_name "qtadvanceddocking")
 if(BUILD_STATIC)
     add_library(${library_name} STATIC ${ads_SRCS} ${ads_HEADERS})
     target_compile_definitions( ${library_name} PUBLIC ADS_STATIC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ if (UNIX AND NOT APPLE)
     set(ads_HEADERS linux/FloatingWidgetTitleBar.h ${ads_HEADERS})
 endif()
 
-set(library_name "qtadvanceddocking")
+set(library_name "qtadvanceddocking-qt${QT_VERSION_MAJOR}")
 if(BUILD_STATIC)
     add_library(${library_name} STATIC ${ads_SRCS} ${ads_HEADERS})
     target_compile_definitions( ${library_name} PUBLIC ADS_STATIC)


### PR DESCRIPTION
See issue https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/682

This fixes the deployment issues with `windeployqt`.

# Before

```
$> cd build\x64\bin\Debug
$> windeployqt --dry-run --list mapping .\SimpleExample.exe
Unable to find dependent libraries of C:\Qt\6.6.3\msvc2019_64\bin\qt6advanceddockingd.dll :Cannot open 'C:/Qt/6.6.3/msvc2019_64/bin/qt6advanceddockingd.dll': The system cannot find the file specified.
```

# After

```
$> cd build\x64\bin\Debug
$> windeployqt --dry-run --list mapping .\SimpleExample.exe
Adding in plugin type generic for module: Qt6Gui
Adding in plugin type iconengines for module: Qt6Gui
Adding in plugin type imageformats for module: Qt6Gui
Adding in plugin type networkinformation for module: Qt6Network
Adding in plugin type platforminputcontexts for module: Qt6Gui
Adding in plugin type platforms for module: Qt6Gui
Adding in plugin type styles for module: Qt6Widgets
Adding in plugin type tls for module: Qt6Network
Warning: Cannot find Visual Studio installation directory, VCINSTALLDIR is not set.
"C:\Qt\6.6.3\msvc2019_64\bin\Qt6Cored.dll" "Qt6Cored.dll"
"C:\Qt\6.6.3\msvc2019_64\bin\Qt6Guid.dll" "Qt6Guid.dll"
"C:\Qt\6.6.3\msvc2019_64\bin\Qt6Networkd.dll" "Qt6Networkd.dll"
"C:\Qt\6.6.3\msvc2019_64\bin\Qt6Svgd.dll" "Qt6Svgd.dll"
"C:\Qt\6.6.3\msvc2019_64\bin\Qt6Widgetsd.dll" "Qt6Widgetsd.dll"
"C:\Qt\6.6.3\msvc2019_64\bin\opengl32sw.dll" "opengl32sw.dll"
"C:\Qt\6.6.3\msvc2019_64\bin\D3Dcompiler_47.dll" "D3Dcompiler_47.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\generic\qtuiotouchplugind.dll" "generic\qtuiotouchplugind.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\iconengines\qsvgicond.dll" "iconengines\qsvgicond.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\imageformats\qgifd.dll" "imageformats\qgifd.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\imageformats\qicod.dll" "imageformats\qicod.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\imageformats\qjpegd.dll" "imageformats\qjpegd.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\imageformats\qsvgd.dll" "imageformats\qsvgd.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\networkinformation\qnetworklistmanagerd.dll" "networkinformation\qnetworklistmanagerd.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\platforms\qwindowsd.dll" "platforms\qwindowsd.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\styles\qwindowsvistastyled.dll" "styles\qwindowsvistastyled.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\tls\qcertonlybackendd.dll" "tls\qcertonlybackendd.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\tls\qopensslbackendd.dll" "tls\qopensslbackendd.dll"
"C:\Qt\6.6.3\msvc2019_64\plugins\tls\qschannelbackendd.dll" "tls\qschannelbackendd.dll"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_ar.qm" "translations\qt_ar.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_ar.qm" "translations\qtbase_ar.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_bg.qm" "translations\qt_bg.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_bg.qm" "translations\qtbase_bg.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_ca.qm" "translations\qt_ca.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_ca.qm" "translations\qtbase_ca.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_cs.qm" "translations\qt_cs.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_cs.qm" "translations\qtbase_cs.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_da.qm" "translations\qt_da.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_da.qm" "translations\qtbase_da.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_de.qm" "translations\qt_de.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_de.qm" "translations\qtbase_de.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_en.qm" "translations\qt_en.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_en.qm" "translations\qtbase_en.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_es.qm" "translations\qt_es.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_es.qm" "translations\qtbase_es.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_fa.qm" "translations\qt_fa.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_fa.qm" "translations\qtbase_fa.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_fi.qm" "translations\qt_fi.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_fi.qm" "translations\qtbase_fi.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_fr.qm" "translations\qt_fr.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_fr.qm" "translations\qtbase_fr.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_gd.qm" "translations\qt_gd.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_gd.qm" "translations\qtbase_gd.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_he.qm" "translations\qt_he.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_he.qm" "translations\qtbase_he.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_hr.qm" "translations\qt_hr.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_hr.qm" "translations\qtbase_hr.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_hu.qm" "translations\qt_hu.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_hu.qm" "translations\qtbase_hu.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_it.qm" "translations\qt_it.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_it.qm" "translations\qtbase_it.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_ja.qm" "translations\qt_ja.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_ja.qm" "translations\qtbase_ja.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_ko.qm" "translations\qt_ko.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_ko.qm" "translations\qtbase_ko.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_lv.qm" "translations\qt_lv.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_lv.qm" "translations\qtbase_lv.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_nl.qm" "translations\qt_nl.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_nl.qm" "translations\qtbase_nl.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_nn.qm" "translations\qt_nn.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_nn.qm" "translations\qtbase_nn.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_pl.qm" "translations\qt_pl.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_pl.qm" "translations\qtbase_pl.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_pt_BR.qm" "translations\qt_pt_BR.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_pt_BR.qm" "translations\qtbase_pt_BR.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_ru.qm" "translations\qt_ru.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_ru.qm" "translations\qtbase_ru.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_sk.qm" "translations\qt_sk.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_sk.qm" "translations\qtbase_sk.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_tr.qm" "translations\qt_tr.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_tr.qm" "translations\qtbase_tr.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_uk.qm" "translations\qt_uk.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_uk.qm" "translations\qtbase_uk.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_zh_CN.qm" "translations\qt_zh_CN.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_zh_CN.qm" "translations\qtbase_zh_CN.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qt_zh_TW.qm" "translations\qt_zh_TW.qm"
"C:\Qt\6.6.3\msvc2019_64\translations\qtbase_zh_TW.qm" "translations\qtbase_zh_TW.qm"
```