### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ highlights are:
 - Simple Drag & Drop user interface.
 - Load data from file.
 - Connect to live streaming of data.
-- Save the visualization layout and configurations to re-use them later.
+- Save the visualization layout and configurations to reuse them later.
 - Fast OpenGL visualization.
 - Can handle thousands of timeseries and millions of data points.
 - Transform your data using a simple editor: derivative, moving average, integral, etc…

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -847,7 +847,7 @@ When an entire area is closed, the default behavior is to hide the dock widgets 
 
 It is possible to globally lock features of all dock widgets to "freeze" the
 current workspace layout. That means, you can now lock your workspace
-to avoid accidentally dragging a docked view. When locking was't possible,
+to avoid accidentally dragging a docked view. When locking wasn't possible,
 users had to manually dock it back to the desired place after each accidental
 undock.
 

--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -270,7 +270,7 @@ struct DockAreaWidgetPrivate
 	DockAreaWidgetPrivate(CDockAreaWidget* _public);
 
 	/**
-	 * Convencience function to ease components factory access
+	 * Convenience function to ease components factory access
 	 */
 	QSharedPointer<ads::CDockComponentsFactory> componentsFactory() const
 	{

--- a/src/DockComponentsFactory.h
+++ b/src/DockComponentsFactory.h
@@ -67,7 +67,7 @@ public:
 
 	/**
 	 * This returns the default dock components factory instance.
-	 * If no components factory is assigned to a specifc dock manager, this
+	 * If no components factory is assigned to a specific dock manager, this
 	 * global factory instance will be used.
 	 */
     static QSharedPointer<ads::CDockComponentsFactory> factory();

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -555,7 +555,7 @@ CDockManager::~CDockManager()
 	{
 		if (!area || area->dockManager() != this) continue;
 
-		// QPointer delete safety - just in case some dock wigdet in destruction
+		// QPointer delete safety - just in case some dock widget in destruction
 		// deletes another related/twin or child dock widget.
 		std::vector<QPointer<QWidget>> deleteWidgets;
 		for ( auto widget : area->dockWidgets() )

--- a/src/ads_globals.cpp
+++ b/src/ads_globals.cpp
@@ -283,7 +283,7 @@ QString detectWindowManagerX11()
 	}
 	if(sup_windows.length() == 0)
 	{
-		ADS_PRINT("Failed to get the supporting window on non EWMH comform WM.");
+		ADS_PRINT("Failed to get the supporting window on non EWMH conform WM.");
 		return "UNKNOWN";
 	}
 	support_win = sup_windows[0];

--- a/src/ads_globals.h
+++ b/src/ads_globals.h
@@ -236,7 +236,7 @@ SideBarLocation toSideBarLocation(DockWidgetArea Area);
 
 
 /**
- * Returns true for the top or bottom side bar ansd false for the
+ * Returns true for the top or bottom side bar and false for the
  * left and right side bar
  */
 bool isHorizontalSideBarLocation(SideBarLocation Location);


### PR DESCRIPTION
Found via `codespell -q 3 -L te,ridiculus,varius`

There are several typos I didn't include that perhaps at a later date can be fixed. 
```
./demo/images/material_icons_license.txt:2: commerical ==> commercial
./src/DockAreaTitleBar.cpp:100: overlayed ==> overlaid
./src/DockOverlay.cpp:915: Offest ==> Offset
./src/DockOverlay.cpp:917: Offest ==> Offset
```