### PR TITLE
update minimum CMake version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if (POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_demo VERSION ${VERSION_SHORT}) 
 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(QtADSExamples LANGUAGES CXX VERSION ${VERSION_SHORT})
 add_subdirectory(simple)
 add_subdirectory(hideshow)

--- a/examples/autohide/CMakeLists.txt
+++ b/examples/autohide/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_autohide VERSION ${VERSION_SHORT}) 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/examples/autohidedragndrop/CMakeLists.txt
+++ b/examples/autohidedragndrop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_autohide_dragndrop VERSION ${VERSION_SHORT})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/examples/centralwidget/CMakeLists.txt
+++ b/examples/centralwidget/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_centralwidget VERSION ${VERSION_SHORT}) 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/examples/configflags/CMakeLists.txt
+++ b/examples/configflags/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_centralwidget VERSION ${VERSION_SHORT}) 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/examples/deleteonclose/CMakeLists.txt
+++ b/examples/deleteonclose/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_deleteonclose VERSION ${VERSION_SHORT}) 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/examples/dockindock/CMakeLists.txt
+++ b/examples/dockindock/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_dockindock VERSION ${VERSION_SHORT}) 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/examples/emptydockarea/CMakeLists.txt
+++ b/examples/emptydockarea/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_centralwidget VERSION ${VERSION_SHORT}) 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/examples/hideshow/CMakeLists.txt
+++ b/examples/hideshow/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_hideshow VERSION ${VERSION_SHORT}) 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/examples/sidebar/CMakeLists.txt
+++ b/examples/sidebar/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_sidebar VERSION ${VERSION_SHORT}) 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ads_example_simple VERSION ${VERSION_SHORT}) 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(QtAdvancedDockingSystem LANGUAGES CXX VERSION ${VERSION_SHORT})
 include(GNUInstallDirs)
 if (${QT_VERSION_MAJOR})


### PR DESCRIPTION
When building with a current version of CMake this warning occures:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max>
syntax
  to tell CMake that the project requires at least <min> but has been
updated
  to work with policies introduced by <max> or earlier.
```

Since Qt 6 already [requires at least CMake 3.16](https://doc.qt.io/qt-6/cmake-supported-cmake-versions.html) (which was released in 2019), I have chosen this as the minimum version.


If this is not desired, at least the compatibility with this version (and the included policies) could be specified: `cmake_minimum_required(VERSION 3.5...3.16)`