### PR TITLE
Always show TitleBar if it contains any explicit actions

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -854,10 +854,22 @@ void CDockAreaWidget::updateTitleBarVisibility()
     bool IsAutoHide = isAutoHide();
     if (!CDockManager::testConfigFlag(CDockManager::AlwaysShowTabs))
     {
-		bool Hidden = Container->hasTopLevelDockWidget() && (Container->isFloating()
-			|| CDockManager::testConfigFlag(CDockManager::HideSingleCentralWidgetTitleBar));
-		Hidden |= (d->Flags.testFlag(HideSingleWidgetTitleBar) && openDockWidgetsCount() == 1);
-		Hidden &= !IsAutoHide; // Titlebar must always be visible when auto hidden so it can be dragged
+        bool Hidden = false;
+        if (!IsAutoHide)  // Titlebar must always be visible when auto hidden so it can be dragged
+        {
+            if (Container->isFloating() || CDockManager::testConfigFlag(CDockManager::HideSingleCentralWidgetTitleBar))
+            {
+                // Always show title bar if it contains title bar actions
+                if (CDockWidget* TopLevelWidget = Container->topLevelDockWidget())
+                    Hidden |= TopLevelWidget->titleBarActions().empty();
+            }
+            if (!Hidden && d->Flags.testFlag(HideSingleWidgetTitleBar))
+            {
+                // Always show title bar if it contains title bar actions
+                auto DockWidgets = openedDockWidgets();
+                Hidden |= (DockWidgets.size() == 1) && DockWidgets.front()->titleBarActions().empty();
+            }
+        }
 		d->TitleBar->setVisible(!Hidden);
     }
 


### PR DESCRIPTION
As proposed in discussion #719, the Title Bar should probably not be hidden if it contains any explicit set Actions. This would be a way to achieve this without further configuration switches.