### PR TITLE
Fixed crash caused by unparented widgets after restoring layout

### DIFF
--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -841,9 +841,9 @@ void CDockWidget::saveState(QXmlStreamWriter& s) const
 void CDockWidget::flagAsUnassigned()
 {
 	d->Closed = true;
-	setParent(d->DockManager);
 	setVisible(false);
 	setDockArea(nullptr);
+	setParent(d->DockManager);
 	tabWidget()->setParent(this);
 }
 


### PR DESCRIPTION
This is essentially due to `setDockArea` undoing the earlier `setParent`.