### PR TITLE
Fix nasty and still unclear bug with "Close Other" not closing all ta…

### DIFF
--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -334,27 +334,13 @@ void CDockAreaTabBar::onTabCloseRequested()
 void CDockAreaTabBar::onCloseOtherTabsRequested()
 {
 	auto Sender = qobject_cast<CDockWidgetTab*>(sender());
-	for (int i = 0; i < count(); ++i)
-	{
-		auto Tab = tab(i);
-		if (Tab->isClosable() && !Tab->isHidden() && Tab != Sender)
-		{
-			// If the dock widget is deleted with the closeTab() call, its tab
-			// it will no longer be in the layout, and thus the index needs to
-			// be updated to not skip any tabs
-			int Offset = Tab->dockWidget()->features().testFlag(
-				CDockWidget::DockWidgetDeleteOnClose) ? 1 : 0;
-			closeTab(i);
 
-			// If the dock widget blocks closing, i.e. if the flag
-			// CustomCloseHandling is set, and the dock widget is still open,
-			// then we do not need to correct the index
-			if (Tab->dockWidget()->isClosed())
-			{
-				i -= Offset;
-			}
-		}
-	}
+    for (int i = count() - 1; i >= 0; --i) {
+        auto Tab = tab(i);
+        if (Tab->isClosable() && !Tab->isHidden() && Tab != Sender) {
+            closeTab(i);
+        }
+    }
 }
 
 


### PR DESCRIPTION
In certain conditions, not clear which, when clicking on "Close Others", not all tabs are closed as expected, but one or two tabs are left open.
As said, it's not clear the origin of this bug. But we can consistently trigger it in our application.
Likely, the issue is a race condition between the Q_EMIT on requesting the close of the tab, and the subsequent isClosed test in the code handling the command.
Fortunately, there's a easy and elegant solution, that is, instead of fixing the tab index based on the close state of the being-closed tab, we can count backward and ignore wheather the tab was closed or not. This totally avoid the async problem with the user request.
This fixes the issue on our application and still works on the demo app.