### PR TITLE
fix compile with Qt 6.9.0 - qplatformnativeinterface.h missing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,11 @@ add_library(ads::${library_name} ALIAS ${library_name})
 target_link_libraries(${library_name} PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)
+
+if(QT_VERSION_MAJOR STREQUAL "6")
+    target_link_libraries(${library_name} PRIVATE Qt6::GuiPrivate) #needed for <qpa/qplatformnativeinterface.h>
+endif()
+
 if (UNIX AND NOT APPLE)
   if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
       find_package(X11 REQUIRED)


### PR DESCRIPTION
This was previously handled here:

if (UNIX AND NOT APPLE)
    include_directories(${Qt${QT_VERSION_MAJOR}Gui_PRIVATE_INCLUDE_DIRS})
endif()

but it seems Qt is phasing this out in favor of explicit cmake targets added in Qt 6.

btw, my Ubunut 22.04 also needed the following libs after upgrading from 6.7.2:
sudo apt install libxkbcommon-dev libxkbfile-dev libxcb-xkb-dev