### PR TITLE
Remove dangling pointer to tab widget when removing an autohide widget

### DIFF
--- a/src/AutoHideDockContainer.cpp
+++ b/src/AutoHideDockContainer.cpp
@@ -425,8 +425,8 @@ void CAutoHideDockContainer::cleanupAndDelete()
 	const auto dockWidget = d->DockWidget;
 	if (dockWidget)
 	{
-
 		auto SideTab = d->SideTab;
+		dockWidget->setSideTabWidget(nullptr);
         SideTab->removeFromSideBar();
         SideTab->setParent(nullptr);
         SideTab->hide();


### PR DESCRIPTION
Would fix #739
Tested locally.  Results below

![image](https://github.com/user-attachments/assets/c3f5a67b-0562-4603-8e83-2cdf803d0e79)

I am still unsure wether ``DockWidget::isAutoHide()`` should query the dockArea. 

Also, I find it a bit weird that the pointer is assigned by ``CAutoHideSideBar`` but removed by ``AutoHideDockContainer``. But looking at the call graph, every one calls the ``CAutoHideDockContainer::cleanupAndDelete`` function while ``CAutoHideSideBar.removeAutoHideWidget``  is only called when a tab moves from one sidebar to another.