### PR TITLE
Add a perDockWidget ContextMenu hook

### DIFF
--- a/src/AutoHideTab.cpp
+++ b/src/AutoHideTab.cpp
@@ -408,6 +408,11 @@ void CAutoHideTab::contextMenuEvent(QContextMenuEvent* ev)
 	Action = Menu.addAction(tr("Close"), this, SLOT(requestCloseDockWidget()));
 	Action->setEnabled(d->DockWidget->features().testFlag(CDockWidget::DockWidgetClosable));
 
+	if (d->DockWidget)
+	{
+		d->DockWidget->ExtendContextMenu(&Menu);
+	}
+
 	Menu.exec(ev->globalPos());
 }
 

--- a/src/AutoHideTab.cpp
+++ b/src/AutoHideTab.cpp
@@ -410,7 +410,7 @@ void CAutoHideTab::contextMenuEvent(QContextMenuEvent* ev)
 
 	if (d->DockWidget)
 	{
-		d->DockWidget->ExtendContextMenu(&Menu);
+		d->DockWidget->extendContextMenu(&Menu);
 	}
 
 	Menu.exec(ev->globalPos());

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -1368,6 +1368,14 @@ CDockWidget::eToolBarStyleSource CDockWidget::toolBarStyleSource() const
 }
 
 
+//============================================================================
+void CDockWidget::ExtendContextMenu(QMenu* Menu) const
+{
+	ADS_PRINT("ExtendContextMenu(): " << this->windowTitle());
+	Q_UNUSED(Menu);
+}
+
+
 } // namespace ads
 
 //---------------------------------------------------------------------------

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -1369,9 +1369,9 @@ CDockWidget::eToolBarStyleSource CDockWidget::toolBarStyleSource() const
 
 
 //============================================================================
-void CDockWidget::ExtendContextMenu(QMenu* Menu) const
+void CDockWidget::extendContextMenu(QMenu* Menu) const
 {
-	ADS_PRINT("ExtendContextMenu(): " << this->windowTitle());
+	ADS_PRINT("extendContextMenu(): " << this->windowTitle());
 	Q_UNUSED(Menu);
 }
 

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -31,6 +31,7 @@
 //                                   INCLUDES
 //============================================================================
 #include <QFrame>
+#include <QMenu>
 
 #include "ads_globals.h"
 

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -569,6 +569,13 @@ public:
      */
     virtual QList<QAction*> titleBarActions() const;
 
+    /**
+     * Hook called after creating the dock widget context menu from a tab or autohide side tab.
+     * Called before being shown to the user. Allow custom extensions of the menu. 
+     * Initially introduced to permit the "Rename" feature
+     */
+    virtual void ExtendContextMenu(QMenu* Menu) const;
+
 
 #ifndef QT_NO_TOOLTIP
     /**

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -575,7 +575,7 @@ public:
      * Called before being shown to the user. Allow custom extensions of the menu. 
      * Initially introduced to permit the "Rename" feature
      */
-    virtual void ExtendContextMenu(QMenu* Menu) const;
+    virtual void extendContextMenu(QMenu* Menu) const;
 
 
 #ifndef QT_NO_TOOLTIP

--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -573,6 +573,11 @@ QMenu* CDockWidgetTab::buildContextMenu(QMenu *Menu)
 		Action = Menu->addAction(tr("Close Others"), this, SIGNAL(closeOtherTabsRequested()));
 	}
 
+	if (d->DockWidget)
+	{
+		d->DockWidget->ExtendContextMenu(Menu);
+	}
+
     return Menu;
 }
 //============================================================================

--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -575,7 +575,7 @@ QMenu* CDockWidgetTab::buildContextMenu(QMenu *Menu)
 
 	if (d->DockWidget)
 	{
-		d->DockWidget->ExtendContextMenu(Menu);
+		d->DockWidget->extendContextMenu(Menu);
 	}
 
     return Menu;


### PR DESCRIPTION
Add an overridable hook to extend the context menus. 
Would allow someone to extend the CDockWidget class to add some custome feature.

Main goal is to add a "Rename" feature in my project. 