### PR TITLE
fix some clazy warnings and crashes

### DIFF
--- a/demo/ImageViewer.cpp
+++ b/demo/ImageViewer.cpp
@@ -144,7 +144,10 @@ void CImageViewer::open()
     QFileDialog dialog(this, tr("Open File"));
     initializeImageFileDialog(dialog, QFileDialog::AcceptOpen);
 
-    while (dialog.exec() == QDialog::Accepted && !loadFile(dialog.selectedFiles().first())) {}
+    auto selectedFiles = dialog.selectedFiles();
+    while (dialog.exec() == QDialog::Accepted && !loadFile(selectedFiles.first()))
+    {
+    }
 }
 
 

--- a/examples/autohide/mainwindow.cpp
+++ b/examples/autohide/mainwindow.cpp
@@ -89,9 +89,9 @@ void CMainWindow::createPerspectiveUi()
 	PerspectiveComboBox = new QComboBox(this);
 	PerspectiveComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 	PerspectiveComboBox->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-	connect(PerspectiveComboBox, SIGNAL(currentTextChanged(const QString&)),
-		DockManager, SLOT(openPerspective(const QString&)));
-	PerspectiveListAction->setDefaultWidget(PerspectiveComboBox);
+    connect(PerspectiveComboBox, &QComboBox::currentTextChanged, DockManager,
+            &ads::CDockManager::openPerspective);
+    PerspectiveListAction->setDefaultWidget(PerspectiveComboBox);
 	ui->toolBar->addSeparator();
 	ui->toolBar->addAction(PerspectiveListAction);
 	ui->toolBar->addAction(SavePerspectiveAction);

--- a/examples/autohidedragndrop/mainwindow.cpp
+++ b/examples/autohidedragndrop/mainwindow.cpp
@@ -93,11 +93,11 @@ void CMainWindow::createPerspectiveUi()
 	PerspectiveComboBox = new QComboBox(this);
 	PerspectiveComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 	PerspectiveComboBox->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-	connect(PerspectiveComboBox, SIGNAL(currentTextChanged(const QString&)),
-		DockManager, SLOT(openPerspective(const QString&)));
-	PerspectiveListAction->setDefaultWidget(PerspectiveComboBox);
-	ui->toolBar->addSeparator();
-	ui->toolBar->addAction(PerspectiveListAction);
+    connect(PerspectiveComboBox, &QComboBox::currentTextChanged, DockManager,
+            &ads::CDockManager::openPerspective);
+    PerspectiveListAction->setDefaultWidget(PerspectiveComboBox);
+    ui->toolBar->addSeparator();
+    ui->toolBar->addAction(PerspectiveListAction);
 	ui->toolBar->addAction(SavePerspectiveAction);
 }
 

--- a/examples/centralwidget/mainwindow.cpp
+++ b/examples/centralwidget/mainwindow.cpp
@@ -91,16 +91,17 @@ CMainWindow::~CMainWindow()
 void CMainWindow::createPerspectiveUi()
 {
 	SavePerspectiveAction = new QAction("Create Perspective", this);
-	connect(SavePerspectiveAction, SIGNAL(triggered()), SLOT(savePerspective()));
-	PerspectiveListAction = new QWidgetAction(this);
+    connect(SavePerspectiveAction, SIGNAL(triggered()), this,
+            SLOT(savePerspective()));
+    PerspectiveListAction = new QWidgetAction(this);
 	PerspectiveComboBox = new QComboBox(this);
 	PerspectiveComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 	PerspectiveComboBox->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-	connect(PerspectiveComboBox, SIGNAL(currentTextChanged(const QString&)),
-		DockManager, SLOT(openPerspective(const QString&)));
-	PerspectiveListAction->setDefaultWidget(PerspectiveComboBox);
-	ui->toolBar->addSeparator();
-	ui->toolBar->addAction(PerspectiveListAction);
+    connect(PerspectiveComboBox, &QComboBox::currentTextChanged, DockManager,
+            &ads::CDockManager::openPerspective);
+    PerspectiveListAction->setDefaultWidget(PerspectiveComboBox);
+    ui->toolBar->addSeparator();
+    ui->toolBar->addAction(PerspectiveListAction);
 	ui->toolBar->addAction(SavePerspectiveAction);
 }
 

--- a/examples/deleteonclose/main.cpp
+++ b/examples/deleteonclose/main.cpp
@@ -35,17 +35,23 @@ int main(int argc, char *argv[])
     ads::CDockManager::setConfigFlag(ads::CDockManager::AllTabsHaveCloseButton, true);
     auto dockManager = new ads::CDockManager(&w);
     w.setDockManager(dockManager);
-    QObject::connect(dockManager, &ads::CDockManager::focusedDockWidgetChanged, [] (ads::CDockWidget* old, ads::CDockWidget* now) {
-        static int Count = 0;
-    	qDebug() << Count++ << " CDockManager::focusedDockWidgetChanged old: " << (old ? old->objectName() : "-") << " now: " << now->objectName() << " visible: " << now->isVisible();
-        now->widget()->setFocus();
-    });
+    QObject::connect(dockManager, &ads::CDockManager::focusedDockWidgetChanged,
+                     &w, [](ads::CDockWidget* old, ads::CDockWidget* now) {
+                         static int Count = 0;
+                         qDebug()
+                             << Count++
+                             << " CDockManager::focusedDockWidgetChanged old: "
+                             << (old ? old->objectName() : "-")
+                             << " now: " << now->objectName()
+                             << " visible: " << now->isVisible();
+                         now->widget()->setFocus();
+                     });
 
     QAction *action = new QAction("New [DockWidgetDeleteOnClose]", &w);
     w.menuBar()->addAction(action);
 
     int i = 0;
-    QObject::connect(action, &QAction::triggered, [&]() {
+    QObject::connect(action, &QAction::triggered, &w, [&]() {
         auto dw = dockManager->createDockWidget(QStringLiteral("test %1 [DockWidgetDeleteOnClose]").arg(i++), &w);
         auto editor = new QTextEdit(QStringLiteral("lorem ipsum..."), dw);
         dw->setWidget(editor);
@@ -53,12 +59,14 @@ int main(int argc, char *argv[])
         auto area = dockManager->addDockWidgetTab(ads::CenterDockWidgetArea, dw);
         qDebug() << "doc dock widget created!" << dw << area;
     });
-	
-    auto dw = dockManager->createDockWidget(QStringLiteral("test %1 [DeleteContentOnClose]").arg(i++), &w);
-	auto editor = new QTextEdit(QStringLiteral("recreated lorem ipsum......"), dw);
-	dw->setWidget(editor);
-	dw->setFeature(ads::CDockWidget::DeleteContentOnClose, true);
-	dw->setWidgetFactory([](QWidget* dw)
+
+    auto dw = dockManager->createDockWidget(
+        QStringLiteral("test %1 [DeleteContentOnClose]").arg(i++), &w);
+    auto editor =
+        new QTextEdit(QStringLiteral("recreated lorem ipsum......"), dw);
+    dw->setWidget(editor);
+    dw->setFeature(ads::CDockWidget::DeleteContentOnClose, true);
+    dw->setWidgetFactory([](QWidget* dw)
 	{
 		static int timesRecreated = 0;
 		return new QTextEdit(QStringLiteral("recreated lorem ipsum... times %1").arg(++timesRecreated), dw);
@@ -68,15 +76,17 @@ int main(int argc, char *argv[])
 	
 	action = new QAction("Toggle [DeleteContentOnClose]", &w);
     w.menuBar()->addAction(action);
-	
-	QObject::connect(action, &QAction::triggered, [dw]() {
-		dw->toggleView(dw->isClosed());
-		qDebug() << QString("dock widget %1! contents widget %2!").arg(dw->isClosed() ? "closed" : "open", dw->widget() ? "created" : "deleted");
+
+    QObject::connect(action, &QAction::triggered, dw, [dw]() {
+        dw->toggleView(dw->isClosed());
+        qDebug() << QString("dock widget %1! contents widget %2!")
+                        .arg(dw->isClosed() ? "closed" : "open",
+                             dw->widget() ? "created" : "deleted");
     });
-	
+
     action = new QAction("New", &w);
     w.menuBar()->addAction(action);
-    QObject::connect(action, &QAction::triggered, [&]() {
+    QObject::connect(action, &QAction::triggered, &w, [&]() {
         auto dw = dockManager->createDockWidget(QStringLiteral("test %1").arg(i++), &w);
         auto editor = new QTextEdit(QStringLiteral("lorem ipsum..."), dw);
         dw->setWidget(editor);

--- a/examples/dockindock/dockindock.cpp
+++ b/examples/dockindock/dockindock.cpp
@@ -206,12 +206,12 @@ void DockInDockWidget::fillPerspectivesMenu( QMenu* menu )
     if ( !perspectiveNames.isEmpty() )
     {
         QMenu* load = menu->addMenu( "Load perspective" );
-        for (const auto& name : perspectiveNames)
+        for (auto& name : perspectiveNames)
         {
             load->addAction(new LoadPerspectiveAction( load, name, *this));
         }
         QMenu* remove = menu->addMenu( "Remove perspective" );
-        for (const auto& name : perspectiveNames)
+        for (auto& name : perspectiveNames)
         {
             remove->addAction( new RemovePerspectiveAction( remove, name, *this ));
         }
@@ -290,7 +290,7 @@ void DockInDockWidget::dumpStatus( std::ostream& str, std::string tab )
         ::dumpStatus( str, widget, tab, "" );
     }
 
-    for ( auto closed : getManager()->dockWidgetsMap() )
+    for (auto& closed : getManager()->dockWidgetsMap())
     {
         if ( visibleWidgets.find( closed ) == visibleWidgets.end() )
         {

--- a/examples/dockindock/dockindockmanager.cpp
+++ b/examples/dockindock/dockindockmanager.cpp
@@ -230,7 +230,7 @@ std::vector<ads::CDockWidget*> DockInDockManager::getWidgetsInGUIOrder() const
     result.reserve( dockWidgetsMap().size() );
     for ( int i = 0; i != dockAreaCount(); ++i )
     {
-        for ( auto widget : dockArea(i)->dockWidgets() )
+        for (auto& widget : dockArea(i)->dockWidgets())
             result.push_back( widget );
     }
     return result;

--- a/examples/dockindock/perspectives.cpp
+++ b/examples/dockindock/perspectives.cpp
@@ -21,7 +21,7 @@ PerspectivesManager::PerspectivesManager( const QString& perspectivesFolder ) :
 PerspectivesManager::~PerspectivesManager()
 {
     // remove temp files:
-    for ( auto perspective : m_perspectives )
+    for (auto& perspective : m_perspectives)
     {
         QString fileName = perspective.settings->fileName();
         perspective.settings.reset();
@@ -82,31 +82,38 @@ void PerspectivesManager::openPerspective( const QString& name, DockInDockWidget
             if ( widget.canCreateNewGroups() )
             {
                 auto curGroups = widget.getManager()->allManagers(true,true);
-                for ( auto group : m_perspectives[name].groups.keys() )
+
+                auto groups = m_perspectives[name].groups;
+                for (auto pgroup = groups.keyBegin(); pgroup != groups.keyEnd();
+                     pgroup++)
                 {
+                    auto group = *pgroup;
                     bool found = false;
-                    for ( auto curgroup : curGroups )
+                    for (auto curgroup : curGroups)
                     {
-                        if ( curgroup->getPersistGroupName() == group )
+                        if (curgroup->getPersistGroupName() == group)
                         {
                             found = true;
                             break;
                         }
                     }
-                    if ( !found )
+                    if (!found)
                     {
-                        group = DockInDockManager::getGroupNameFromPersistGroupName( group );
+                        group =
+                            DockInDockManager::getGroupNameFromPersistGroupName(
+                                group);
 
                         // restore group in file but not in GUI yet
                         ads::CDockAreaWidget* insertPos = NULL;
-                        widget.createGroup( group, insertPos );
+                        widget.createGroup(group, insertPos);
                     }
                 }
 
-                curGroups = widget.getManager()->allManagers(false,true);
+                curGroups = widget.getManager()->allManagers(false, true);
                 for ( auto curgroup : curGroups )
                 {
-                    if ( !m_perspectives[name].groups.keys().contains( curgroup->getPersistGroupName() ) )
+                    if (!m_perspectives[name].groups.contains(
+                            curgroup->getPersistGroupName()))
                     {
                         widget.destroyGroup( &curgroup->parent() );
                     }
@@ -114,27 +121,34 @@ void PerspectivesManager::openPerspective( const QString& name, DockInDockWidget
             }
 
             auto managers = widget.getManager()->allManagers(true,true);
-            for ( auto group : m_perspectives[name].groups.keys() )
+            auto groups = m_perspectives[name].groups;
+            for (auto pgroup = groups.keyBegin(); pgroup != groups.keyEnd();
+                 pgroup++)
             {
-                for ( auto mgr : managers )
+                auto group = *pgroup;
+                for (auto mgr : managers)
                 {
-                    if ( mgr->getPersistGroupName() == group )
+                    if (mgr->getPersistGroupName() == group)
                     {
-                        for ( QString widgetName : m_perspectives[name].groups[group] )
+                        for (auto& widgetName :
+                             m_perspectives[name].groups[group])
                         {
-                            ads::CDockWidget* widget = findWidget( widgetName, { mgr } );
-                            if ( widget )
+                            ads::CDockWidget* widget =
+                                findWidget(widgetName, {mgr});
+                            if (widget)
                             {
                                 // OK, widget is already in the good manager!
                             }
                             else
                             {
-                                widget = findWidget( widgetName, managers );
-                                if ( widget )
+                                widget = findWidget(widgetName, managers);
+                                if (widget)
                                 {
-                                    // move dock widget in the same group as it used to be when perspective was saved
-                                    // this guarantee load/open perspectives will work smartly
-                                    MoveDockWidgetAction::move( widget, mgr );
+                                    // move dock widget in the same group as it
+                                    // used to be when perspective was saved this
+                                    // guarantee load/open perspectives will work
+                                    // smartly
+                                    MoveDockWidgetAction::move(widget, mgr);
                                 }
                             }
                         }
@@ -219,7 +233,7 @@ void PerspectivesManager::loadPerspectives()
 
                 // load group info:
                 mainSettings->beginGroup(GROUP_PREFIX);
-                for (const auto& key : mainSettings->allKeys())
+                for (auto& key : mainSettings->allKeys())
                 {
                     m_perspectives[perspective].groups[key] = mainSettings->value( key ).toStringList();
                 }
@@ -246,23 +260,36 @@ void PerspectivesManager::savePerspectives() const
         // Save list of perspective and group organization
         mainSettings->beginWriteArray("Perspectives", m_perspectives.size());
         int i = 0;
-        for ( auto perspective : m_perspectives.keys() )
+
+        for (auto pperspective = m_perspectives.keyBegin();
+             pperspective != m_perspectives.keyEnd(); pperspective++)
         {
+            auto perspective = *pperspective;
+
             mainSettings->setArrayIndex(i);
             mainSettings->setValue("Name", perspective);
             mainSettings->beginGroup(GROUP_PREFIX);
-            for ( auto group : m_perspectives[perspective].groups.keys() )
+
+            auto groups = m_perspectives[perspective].groups;
+            for (auto pgroup = groups.keyBegin(); pgroup != groups.keyEnd();
+                 pgroup++)
             {
-                mainSettings->setValue( group, m_perspectives[perspective].groups[group] );
+                auto group = *pgroup;
+                mainSettings->setValue(group,
+                                       m_perspectives[perspective].groups[group]);
             }
+
             mainSettings->endGroup();
             ++i;
         }
+
         mainSettings->endArray();
 
         // Save perspectives themselves
-        for ( auto perspectiveName : m_perspectives.keys() )
+        for (auto pname = m_perspectives.keyBegin();
+             pname != m_perspectives.keyEnd(); pname++)
         {
+            auto perspectiveName = *pname;
             auto toSave = getSettingsFileName( perspectiveName, false );
             QSettings& settings = *(m_perspectives[perspectiveName].settings);
             settings.sync();

--- a/src/AutoHideDockContainer.cpp
+++ b/src/AutoHideDockContainer.cpp
@@ -44,9 +44,6 @@
 #include "AutoHideSideBar.h"
 #include "AutoHideTab.h"
 
-
-#include <iostream>
-
 namespace ads
 {
 static const int ResizeMargin = 30;

--- a/src/AutoHideSideBar.cpp
+++ b/src/AutoHideSideBar.cpp
@@ -183,8 +183,8 @@ CAutoHideSideBar::~CAutoHideSideBar()
 	// The SideTabeBar is not the owner of the tabs and to prevent deletion
 	// we set the parent here to nullptr to remove it from the children
 	auto Tabs = findChildren<CAutoHideTab*>(QString(), Qt::FindDirectChildrenOnly);
-	for (auto Tab : Tabs)
-	{
+    for (auto& Tab : Tabs)
+    {
 		Tab->setParent(nullptr);
 	}
 	delete d;
@@ -443,9 +443,8 @@ int CAutoHideSideBar::spacing() const
 //===========================================================================
 void CAutoHideSideBar::setSpacing(int Spacing)
 {
-	d->TabsLayout->setSpacing(Spacing);
+    d->TabsLayout->setSpacing(Spacing);
 }
-
 
 //===========================================================================
 CDockContainerWidget* CAutoHideSideBar::dockContainer() const

--- a/src/AutoHideTab.cpp
+++ b/src/AutoHideTab.cpp
@@ -139,12 +139,10 @@ struct AutoHideTabPrivate
 	IFloatingWidget* createFloatingWidget(T* Widget)
 	{
 		auto w = new CFloatingDragPreview(Widget);
-		_this->connect(w, &CFloatingDragPreview::draggingCanceled, [this]()
-		{
-			DragState = DraggingInactive;
-		});
-		return w;
-	}
+        QObject::connect(w, &CFloatingDragPreview::draggingCanceled, _this,
+                         [this]() { DragState = DraggingInactive; });
+        return w;
+    }
 }; // struct DockWidgetTabPrivate
 
 

--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -40,13 +40,9 @@
 
 #include "FloatingDockContainer.h"
 #include "DockAreaWidget.h"
-#include "DockOverlay.h"
 #include "DockManager.h"
 #include "DockWidget.h"
 #include "DockWidgetTab.h"
-
-#include <iostream>
-
 
 namespace ads
 {
@@ -197,12 +193,16 @@ int CDockAreaTabBar::count() const
 void CDockAreaTabBar::insertTab(int Index, CDockWidgetTab* Tab)
 {
 	d->TabsLayout->insertWidget(Index, Tab);
-	connect(Tab, SIGNAL(clicked()), this, SLOT(onTabClicked()));
-	connect(Tab, SIGNAL(closeRequested()), this, SLOT(onTabCloseRequested()));
-	connect(Tab, SIGNAL(closeOtherTabsRequested()), this, SLOT(onCloseOtherTabsRequested()));
-	connect(Tab, SIGNAL(moved(QPoint)), this, SLOT(onTabWidgetMoved(QPoint)));
-	connect(Tab, SIGNAL(elidedChanged(bool)), this, SIGNAL(elidedChanged(bool)));
-	Tab->installEventFilter(this);
+    connect(Tab, &CDockWidgetTab::clicked, this, &CDockAreaTabBar::onTabClicked);
+    connect(Tab, &CDockWidgetTab::closeRequested, this,
+            &CDockAreaTabBar::onTabCloseRequested);
+    connect(Tab, &CDockWidgetTab::closeOtherTabsRequested, this,
+            &CDockAreaTabBar::onCloseOtherTabsRequested);
+    connect(Tab, &CDockWidgetTab::moved, this,
+            &CDockAreaTabBar::onTabWidgetMoved);
+    connect(Tab, &CDockWidgetTab::elidedChanged, this,
+            &CDockAreaTabBar::elidedChanged);
+    Tab->installEventFilter(this);
 	Q_EMIT tabInserted(Index);
     if (Index <= d->CurrentIndex)
 	{

--- a/src/DockAreaTitleBar.cpp
+++ b/src/DockAreaTitleBar.cpp
@@ -54,9 +54,6 @@
 #include "DockFocusController.h"
 #include "ElidingLabel.h"
 #include "AutoHideDockContainer.h"
-#include "IconProvider.h"
-
-#include <iostream>
 
 namespace ads
 {
@@ -196,62 +193,79 @@ void DockAreaTitleBarPrivate::createButtons()
 #ifndef QT_NO_TOOLTIP
 	TabsMenu->setToolTipsVisible(true);
 #endif
-	_this->connect(TabsMenu, SIGNAL(aboutToShow()), SLOT(onTabsMenuAboutToShow()));
-	TabsMenuButton->setMenu(TabsMenu);
-	internal::setToolTip(TabsMenuButton, QObject::tr("List All Tabs"));
-	TabsMenuButton->setSizePolicy(ButtonSizePolicy);
-	Layout->addWidget(TabsMenuButton, 0);
-	_this->connect(TabsMenuButton->menu(), SIGNAL(triggered(QAction*)),
-		SLOT(onTabsMenuActionTriggered(QAction*)));
+    QObject::connect(TabsMenu, &QMenu::aboutToShow, _this,
+                     &CDockAreaTitleBar::onTabsMenuAboutToShow);
+    TabsMenuButton->setMenu(TabsMenu);
+    internal::setToolTip(TabsMenuButton, QObject::tr("List All Tabs"));
+    TabsMenuButton->setSizePolicy(ButtonSizePolicy);
+    Layout->addWidget(TabsMenuButton, 0);
+    QObject::connect(TabsMenuButton->menu(), &QMenu::triggered, _this,
+                     &CDockAreaTitleBar::onTabsMenuActionTriggered);
 
-	// Undock button
-	UndockButton = new CTitleBarButton(testConfigFlag(CDockManager::DockAreaHasUndockButton),
-		true, TitleBarButtonUndock);
-	UndockButton->setObjectName("detachGroupButton");
-	UndockButton->setAutoRaise(true);
-	internal::setToolTip(UndockButton, QObject::tr("Detach Group"));
-	internal::setButtonIcon(UndockButton, QStyle::SP_TitleBarNormalButton, ads::DockAreaUndockIcon);
-	UndockButton->setSizePolicy(ButtonSizePolicy);
-	Layout->addWidget(UndockButton, 0);
-	_this->connect(UndockButton, SIGNAL(clicked()), SLOT(onUndockButtonClicked()));
+    // Undock button
+    UndockButton =
+        new CTitleBarButton(testConfigFlag(CDockManager::DockAreaHasUndockButton),
+                            true, TitleBarButtonUndock);
+    UndockButton->setObjectName("detachGroupButton");
+    UndockButton->setAutoRaise(true);
+    internal::setToolTip(UndockButton, QObject::tr("Detach Group"));
+    internal::setButtonIcon(UndockButton, QStyle::SP_TitleBarNormalButton,
+                            ads::DockAreaUndockIcon);
+    UndockButton->setSizePolicy(ButtonSizePolicy);
+    Layout->addWidget(UndockButton, 0);
+    QObject::connect(UndockButton, &CTitleBarButton::clicked, _this,
+                     &CDockAreaTitleBar::onUndockButtonClicked);
 
-	// AutoHide Button
-	const auto autoHideEnabled = testAutoHideConfigFlag(CDockManager::AutoHideFeatureEnabled);
-	AutoHideButton = new CTitleBarButton(testAutoHideConfigFlag(CDockManager::DockAreaHasAutoHideButton) && autoHideEnabled,
-		true, TitleBarButtonAutoHide);
-	AutoHideButton->setObjectName("dockAreaAutoHideButton");
-	AutoHideButton->setAutoRaise(true);
-	internal::setToolTip(AutoHideButton, _this->titleBarButtonToolTip(TitleBarButtonAutoHide));
-	internal::setButtonIcon(AutoHideButton, QStyle::SP_DialogOkButton, ads::AutoHideIcon);
-	AutoHideButton->setSizePolicy(ButtonSizePolicy);
-	AutoHideButton->setCheckable(testAutoHideConfigFlag(CDockManager::AutoHideButtonCheckable));
-	AutoHideButton->setChecked(false);
-	Layout->addWidget(AutoHideButton, 0);
-	_this->connect(AutoHideButton, SIGNAL(clicked()),  SLOT(onAutoHideButtonClicked()));
+    // AutoHide Button
+    const auto autoHideEnabled =
+        testAutoHideConfigFlag(CDockManager::AutoHideFeatureEnabled);
+    AutoHideButton = new CTitleBarButton(
+        testAutoHideConfigFlag(CDockManager::DockAreaHasAutoHideButton)
+            && autoHideEnabled,
+        true, TitleBarButtonAutoHide);
+    AutoHideButton->setObjectName("dockAreaAutoHideButton");
+    AutoHideButton->setAutoRaise(true);
+    internal::setToolTip(AutoHideButton,
+                         _this->titleBarButtonToolTip(TitleBarButtonAutoHide));
+    internal::setButtonIcon(AutoHideButton, QStyle::SP_DialogOkButton,
+                            ads::AutoHideIcon);
+    AutoHideButton->setSizePolicy(ButtonSizePolicy);
+    AutoHideButton->setCheckable(
+        testAutoHideConfigFlag(CDockManager::AutoHideButtonCheckable));
+    AutoHideButton->setChecked(false);
+    Layout->addWidget(AutoHideButton, 0);
+    QObject::connect(AutoHideButton, &CTitleBarButton::clicked, _this,
+                     &CDockAreaTitleBar::onAutoHideButtonClicked);
 
-	// Minimize button
-	MinimizeButton = new CTitleBarButton(testAutoHideConfigFlag(CDockManager::AutoHideHasMinimizeButton),
-		false, TitleBarButtonMinimize);
-	MinimizeButton->setObjectName("dockAreaMinimizeButton");
-	MinimizeButton->setAutoRaise(true);
-	MinimizeButton->setVisible(false);
-	internal::setButtonIcon(MinimizeButton, QStyle::SP_TitleBarMinButton, ads::DockAreaMinimizeIcon);
-	internal::setToolTip(MinimizeButton, QObject::tr("Minimize"));
-	MinimizeButton->setSizePolicy(ButtonSizePolicy);
-	Layout->addWidget(MinimizeButton, 0);
-	_this->connect(MinimizeButton, SIGNAL(clicked()), SLOT(minimizeAutoHideContainer()));
+    // Minimize button
+    MinimizeButton = new CTitleBarButton(
+        testAutoHideConfigFlag(CDockManager::AutoHideHasMinimizeButton), false,
+        TitleBarButtonMinimize);
+    MinimizeButton->setObjectName("dockAreaMinimizeButton");
+    MinimizeButton->setAutoRaise(true);
+    MinimizeButton->setVisible(false);
+    internal::setButtonIcon(MinimizeButton, QStyle::SP_TitleBarMinButton,
+                            ads::DockAreaMinimizeIcon);
+    internal::setToolTip(MinimizeButton, QObject::tr("Minimize"));
+    MinimizeButton->setSizePolicy(ButtonSizePolicy);
+    Layout->addWidget(MinimizeButton, 0);
+    QObject::connect(MinimizeButton, &CTitleBarButton::clicked, _this,
+                     &CDockAreaTitleBar::minimizeAutoHideContainer);
 
-	// Close button
-	CloseButton = new CTitleBarButton(testConfigFlag(CDockManager::DockAreaHasCloseButton),
-		true, TitleBarButtonClose);
-	CloseButton->setObjectName("dockAreaCloseButton");
-	CloseButton->setAutoRaise(true);
-	internal::setButtonIcon(CloseButton, QStyle::SP_TitleBarCloseButton, ads::DockAreaCloseIcon);
+    // Close button
+    CloseButton =
+        new CTitleBarButton(testConfigFlag(CDockManager::DockAreaHasCloseButton),
+                            true, TitleBarButtonClose);
+    CloseButton->setObjectName("dockAreaCloseButton");
+    CloseButton->setAutoRaise(true);
+    internal::setButtonIcon(CloseButton, QStyle::SP_TitleBarCloseButton,
+                            ads::DockAreaCloseIcon);
     internal::setToolTip(CloseButton, _this->titleBarButtonToolTip(TitleBarButtonClose));
 	CloseButton->setSizePolicy(ButtonSizePolicy);
 	CloseButton->setIconSize(QSize(16, 16));
 	Layout->addWidget(CloseButton, 0);
-	_this->connect(CloseButton, SIGNAL(clicked()), SLOT(onCloseButtonClicked()));
+    QObject::connect(CloseButton, &CTitleBarButton::clicked, _this,
+                     &CDockAreaTitleBar::onCloseButtonClicked);
 }
 
 
@@ -273,14 +287,22 @@ void DockAreaTitleBarPrivate::createTabBar()
 	TabBar = componentsFactory()->createDockAreaTabBar(DockArea);
     TabBar->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 	Layout->addWidget(TabBar);
-	_this->connect(TabBar, SIGNAL(tabClosed(int)), SLOT(markTabsMenuOutdated()));
-	_this->connect(TabBar, SIGNAL(tabOpened(int)), SLOT(markTabsMenuOutdated()));
-	_this->connect(TabBar, SIGNAL(tabInserted(int)), SLOT(markTabsMenuOutdated()));
-	_this->connect(TabBar, SIGNAL(removingTab(int)), SLOT(markTabsMenuOutdated()));
-	_this->connect(TabBar, SIGNAL(tabMoved(int, int)), SLOT(markTabsMenuOutdated()));
-	_this->connect(TabBar, SIGNAL(currentChanged(int)), SLOT(onCurrentTabChanged(int)));
-	_this->connect(TabBar, SIGNAL(tabBarClicked(int)), SIGNAL(tabBarClicked(int)));
-	_this->connect(TabBar, SIGNAL(elidedChanged(bool)), SLOT(markTabsMenuOutdated()));
+    QObject::connect(TabBar, &CDockAreaTabBar::tabClosed, _this,
+                     &CDockAreaTitleBar::markTabsMenuOutdated);
+    QObject::connect(TabBar, &CDockAreaTabBar::tabOpened, _this,
+                     &CDockAreaTitleBar::markTabsMenuOutdated);
+    QObject::connect(TabBar, &CDockAreaTabBar::tabInserted, _this,
+                     &CDockAreaTitleBar::markTabsMenuOutdated);
+    QObject::connect(TabBar, &CDockAreaTabBar::removingTab, _this,
+                     &CDockAreaTitleBar::markTabsMenuOutdated);
+    QObject::connect(TabBar, &CDockAreaTabBar::tabMoved, _this,
+                     &CDockAreaTitleBar::markTabsMenuOutdated);
+    QObject::connect(TabBar, &CDockAreaTabBar::currentChanged, _this,
+                     &CDockAreaTitleBar::onCurrentTabChanged);
+    QObject::connect(TabBar, &CDockAreaTabBar::tabBarClicked, _this,
+                     &CDockAreaTitleBar::tabBarClicked);
+    QObject::connect(TabBar, &CDockAreaTabBar::elidedChanged, _this,
+                     &CDockAreaTitleBar::markTabsMenuOutdated);
 }
 
 
@@ -303,12 +325,10 @@ IFloatingWidget* DockAreaTitleBarPrivate::makeAreaFloating(const QPoint& Offset,
 	else
 	{
 		auto w = new CFloatingDragPreview(DockArea);
-		QObject::connect(w, &CFloatingDragPreview::draggingCanceled, [this]()
-		{
-			this->DragState = DraggingInactive;
-		});
-		FloatingWidget = w;
-	}
+        QObject::connect(w, &CFloatingDragPreview::draggingCanceled, _this,
+                         [this]() { this->DragState = DraggingInactive; });
+        FloatingWidget = w;
+    }
 
     FloatingWidget->startFloating(Offset, Size, DragState, nullptr);
     if (FloatingDockContainer)
@@ -529,12 +549,12 @@ void CDockAreaTitleBar::updateDockWidgetActionsButtons()
 	CDockWidget* DockWidget = Tab->dockWidget();
 	if (!d->DockWidgetActionsButtons.isEmpty())
 	{
-		for (auto Button : d->DockWidgetActionsButtons)
-		{
-			d->Layout->removeWidget(Button);
+        for (auto& Button : d->DockWidgetActionsButtons)
+        {
+            d->Layout->removeWidget(Button);
 			delete Button;
-		}
-		d->DockWidgetActionsButtons.clear();
+        }
+        d->DockWidgetActionsButtons.clear();
 	}
 
 	auto Actions = DockWidget->titleBarActions();
@@ -544,16 +564,16 @@ void CDockAreaTitleBar::updateDockWidgetActionsButtons()
 	}
 
 	int InsertIndex = indexOf(d->TabsMenuButton);
-	for (auto Action : Actions)
-	{
-		auto Button = new CTitleBarButton(true, false, TitleBarButtonTabsMenu, this);
+    for (auto& Action : Actions)
+    {
+        auto Button = new CTitleBarButton(true, false, TitleBarButtonTabsMenu, this);
 		Button->setDefaultAction(Action);
 		Button->setAutoRaise(true);
 		Button->setPopupMode(QToolButton::InstantPopup);
 		Button->setObjectName(Action->objectName());
 		d->Layout->insertWidget(InsertIndex++, Button, 0);
 		d->DockWidgetActionsButtons.append(Button);
-	}
+    }
 }
 
 
@@ -835,6 +855,7 @@ QMenu* CDockAreaTitleBar::buildContextMenu(QMenu *Menu)
 	{
 		Action = Menu->addAction(tr("Close Other Groups"), d->DockArea, SLOT(closeOtherAreas()));
 	}
+    Q_UNUSED(Action);
     return Menu;
 }
 

--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -28,32 +28,33 @@
 //============================================================================
 //                                   INCLUDES
 //============================================================================
-#include <AutoHideDockContainer.h>
-#include <AutoHideTab.h>
 #include "DockAreaWidget.h"
 
-#include <QStackedLayout>
-#include <QScrollBar>
-#include <QStyle>
-#include <QPushButton>
 #include <QDebug>
-#include <QMenu>
-#include <QXmlStreamWriter>
 #include <QList>
+#include <QMenu>
+#include <QPointer>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QStackedLayout>
+#include <QStyle>
+#include <QWidget>
+#include <QXmlStreamWriter>
 
-#include "ElidingLabel.h"
-#include "DockContainerWidget.h"
-#include "DockWidget.h"
-#include "FloatingDockContainer.h"
-#include "DockManager.h"
-#include "DockOverlay.h"
+#include <AutoHideDockContainer.h>
+#include <AutoHideTab.h>
+
 #include "DockAreaTabBar.h"
-#include "DockSplitter.h"
 #include "DockAreaTitleBar.h"
 #include "DockComponentsFactory.h"
+#include "DockContainerWidget.h"
+#include "DockManager.h"
+#include "DockSplitter.h"
+#include "DockWidget.h"
 #include "DockWidgetTab.h"
 #include "DockingStateReader.h"
-
+#include "ElidingLabel.h"
+#include "FloatingDockContainer.h"
 
 namespace ads
 {
@@ -1124,21 +1125,21 @@ CDockWidget::DockWidgetFeatures CDockAreaWidget::features(eBitwiseOperator Mode)
 	if (BitwiseAnd == Mode)
 	{
 		CDockWidget::DockWidgetFeatures Features(CDockWidget::AllDockWidgetFeatures);
-		for (const auto DockWidget : dockWidgets())
-		{
-			Features &= DockWidget->features();
-		}
-		return Features;
-	}
-	else
-	{
+        for (auto& DockWidget : dockWidgets())
+        {
+            Features &= DockWidget->features();
+        }
+        return Features;
+    }
+    else
+    {
 		CDockWidget::DockWidgetFeatures Features(CDockWidget::NoDockWidgetFeatures);
-		for (const auto DockWidget : dockWidgets())
-		{
-			Features |= DockWidget->features();
-		}
-		return Features;
-	}
+        for (auto& DockWidget : dockWidgets())
+        {
+            Features |= DockWidget->features();
+        }
+        return Features;
+    }
 }
 
 
@@ -1227,7 +1228,7 @@ void CDockAreaWidget::closeArea()
 	}
     else
 	{
-        for (auto DockWidget : openedDockWidgets())
+        for (auto& DockWidget : openedDockWidgets())
         {
 			if ((DockWidget->features().testFlag(CDockWidget::DockWidgetDeleteOnClose) && DockWidget->features().testFlag(CDockWidget::DockWidgetForceCloseWithArea)) ||
 				DockWidget->features().testFlag(CDockWidget::CustomCloseHandling))
@@ -1373,9 +1374,9 @@ void CDockAreaWidget::setAutoHide(bool Enable, SideBarLocation Location, int Tab
 	}
 
 	auto area = (SideBarNone == Location) ? calculateSideTabBarArea() : Location;
-	for (const auto DockWidget : openedDockWidgets())
-	{
-		if (Enable == isAutoHide())
+    for (auto& DockWidget : openedDockWidgets())
+    {
+        if (Enable == isAutoHide())
 		{
 			continue;
 		}
@@ -1386,7 +1387,7 @@ void CDockAreaWidget::setAutoHide(bool Enable, SideBarLocation Location, int Tab
 		}
 
 		dockContainer()->createAndSetupAutoHideContainer(area, DockWidget, TabIndex++);
-	}
+    }
 }
 
 
@@ -1432,8 +1433,8 @@ bool CDockAreaWidget::isCentralWidgetArea() const
 bool CDockAreaWidget::containsCentralWidget() const
 {
 	auto centralWidget = dockManager()->centralWidget();
-	for (const auto &dockWidget : dockWidgets())
-	{
+    for (auto& dockWidget : dockWidgets())
+    {
 		if (dockWidget == centralWidget)
 		{
 			return true;

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -91,11 +91,12 @@ private Q_SLOTS:
 	 */
 	void updateTitleBarButtonsToolTips();
 
-	/**
+private:
+    /**
 	 * Calculate the auto hide side bar location depending on the dock area
 	 * widget position in the container
 	 */
-	SideBarLocation calculateSideTabBarArea() const;
+    ads::SideBarLocation calculateSideTabBarArea() const;
 
 protected:
 
@@ -407,13 +408,14 @@ public Q_SLOTS:
 	 * If the dock area is switched to auto hide mode, then all dock widgets
 	 * that are pinable will be added to the sidebar
 	 */
-	void setAutoHide(bool Enable, SideBarLocation Location = SideBarNone, int TabIndex = -1);
+    void setAutoHide(bool Enable, ads::SideBarLocation Location = SideBarNone,
+                     int TabIndex = -1);
 
-	/**
+    /**
 	 * Switches the dock area to auto hide mode or vice versa depending on its
 	 * current state.
 	 */
-	void toggleAutoHide(SideBarLocation Location = SideBarNone);
+    void toggleAutoHide(ads::SideBarLocation Location = SideBarNone);
 
     /**
 	 * This function closes all other areas except of this area

--- a/src/DockComponentsFactory.cpp
+++ b/src/DockComponentsFactory.cpp
@@ -11,8 +11,6 @@
 #include <AutoHideTab.h>
 #include "DockComponentsFactory.h"
 
-#include <memory>
-
 #include "DockWidgetTab.h"
 #include "DockAreaTabBar.h"
 #include "DockAreaTitleBar.h"
@@ -22,8 +20,8 @@
 namespace ads
 {
 
-static QSharedPointer<ads::CDockComponentsFactory> DefaultFactory;
-
+using FACTORY_SHAREDPOINTER = QSharedPointer<ads::CDockComponentsFactory>;
+Q_GLOBAL_STATIC(FACTORY_SHAREDPOINTER, DefaultFactory);
 
 //============================================================================
 CDockWidgetTab* CDockComponentsFactory::createDockWidgetTab(CDockWidget* DockWidget) const
@@ -55,25 +53,25 @@ CDockAreaTitleBar* CDockComponentsFactory::createDockAreaTitleBar(CDockAreaWidge
 //============================================================================
 QSharedPointer<ads::CDockComponentsFactory> CDockComponentsFactory::factory()
 {
-	if (!DefaultFactory)
-	{
-		DefaultFactory.reset(new CDockComponentsFactory());
-	}
-	return DefaultFactory;
+    if (DefaultFactory->isNull())
+    {
+        DefaultFactory->reset(new CDockComponentsFactory());
+    }
+    return *DefaultFactory;
 }
 
 
 //============================================================================
 void CDockComponentsFactory::setFactory(CDockComponentsFactory* Factory)
 {
-	DefaultFactory.reset(Factory);
+    DefaultFactory->reset(Factory);
 }
 
 
 //============================================================================
 void CDockComponentsFactory::resetDefaultFactory()
 {
-	DefaultFactory.reset(new CDockComponentsFactory());
+    DefaultFactory->reset(new CDockComponentsFactory());
 }
 
 } // namespace ads

--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -60,7 +60,6 @@
 #include "AutoHideTab.h"
 
 #include <functional>
-#include <iostream>
 
 #if QT_VERSION < 0x050900
 
@@ -297,63 +296,66 @@ public:
 		}
 
 		VisibleDockAreaCount = 0;
-		for (auto DockArea : DockAreas)
-		{
-			if (!DockArea)
-			{
-				continue;
-			}
-			VisibleDockAreaCount += (DockArea->isHidden() ? 0 : 1);
-		}
-	}
+        for (auto& DockArea : DockAreas)
+        {
+            if (!DockArea)
+            {
+                continue;
+            }
+            VisibleDockAreaCount += (DockArea->isHidden() ? 0 : 1);
+        }
+    }
 
-	/**
-	 * Access function for the visible dock area counter
-	 */
-	int& visibleDockAreaCount()
-	{
-		// Lazy initialisation - we initialize the VisibleDockAreaCount variable
-		// on first use
-		initVisibleDockAreaCount();
-		return VisibleDockAreaCount;
-	}
+    /**
+     * Access function for the visible dock area counter
+     */
+    int& visibleDockAreaCount()
+    {
+        // Lazy initialisation - we initialize the VisibleDockAreaCount variable
+        // on first use
+        initVisibleDockAreaCount();
+        return VisibleDockAreaCount;
+    }
 
-	/**
-	 * The visible dock area count changes, if dock areas are remove, added or
-	 * when its view is toggled
-	 */
-	void onVisibleDockAreaCountChanged();
+    /**
+     * The visible dock area count changes, if dock areas are remove, added or
+     * when its view is toggled
+     */
+    void onVisibleDockAreaCountChanged();
 
-	void emitDockAreasRemoved()
-	{
-		onVisibleDockAreaCountChanged();
-		Q_EMIT _this->dockAreasRemoved();
-	}
+    void emitDockAreasRemoved()
+    {
+        onVisibleDockAreaCountChanged();
+        Q_EMIT _this->dockAreasRemoved();
+    }
 
-	void emitDockAreasAdded()
-	{
-		onVisibleDockAreaCountChanged();
-		Q_EMIT _this->dockAreasAdded();
-	}
+    void emitDockAreasAdded()
+    {
+        onVisibleDockAreaCountChanged();
+        Q_EMIT _this->dockAreasAdded();
+    }
 
-	/**
-	 * Helper function for creation of new splitter
-	 */
-	CDockSplitter* newSplitter(Qt::Orientation orientation, QWidget* parent = nullptr)
-	{
-		CDockSplitter* s = new CDockSplitter(orientation, parent);
-		s->setOpaqueResize(CDockManager::testConfigFlag(CDockManager::OpaqueSplitterResize));
-		s->setChildrenCollapsible(false);
-		return s;
-	}
+    /**
+     * Helper function for creation of new splitter
+     */
+    CDockSplitter* newSplitter(Qt::Orientation orientation,
+                               QWidget* parent = nullptr)
+    {
+        CDockSplitter* s = new CDockSplitter(orientation, parent);
+        s->setOpaqueResize(
+            CDockManager::testConfigFlag(CDockManager::OpaqueSplitterResize));
+        s->setChildrenCollapsible(false);
+        return s;
+    }
 
-	/**
-	 * Ensures equal distribution of the sizes of a splitter if an dock widget
-	 * is inserted from code
-	 */
-	void adjustSplitterSizesOnInsertion(QSplitter* Splitter, qreal LastRatio = 1.0)
-	{
-		int AreaSize = (Splitter->orientation() == Qt::Horizontal) ? Splitter->width() : Splitter->height();
+    /**
+     * Ensures equal distribution of the sizes of a splitter if an dock widget
+     * is inserted from code
+     */
+    void adjustSplitterSizesOnInsertion(QSplitter* Splitter,
+                                        qreal LastRatio = 1.0)
+    {
+        int AreaSize = (Splitter->orientation() == Qt::Horizontal) ? Splitter->width() : Splitter->height();
 		auto SplitterSizes = Splitter->sizes();
 
 		qreal TotRatio = SplitterSizes.size() - 1.0 + LastRatio;
@@ -363,7 +365,7 @@ public:
 		}
 		SplitterSizes.back() = AreaSize * LastRatio / TotRatio;
 		Splitter->setSizes(SplitterSizes);
-	}
+    }
 
     /**
      * This function forces the dock container widget to update handles of splitters
@@ -396,11 +398,13 @@ DockContainerWidgetPrivate::DockContainerWidgetPrivate(CDockContainerWidget* _pu
 	std::fill(std::begin(LastAddedAreaCache),std::end(LastAddedAreaCache), nullptr);
 	DelayedAutoHideTimer.setSingleShot(true);
 	DelayedAutoHideTimer.setInterval(500);
-	QObject::connect(&DelayedAutoHideTimer, &QTimer::timeout, [this](){
-		auto GlobalPos = DelayedAutoHideTab->mapToGlobal(QPoint(0, 0));
-		qApp->sendEvent(DelayedAutoHideTab, new QMouseEvent(QEvent::MouseButtonPress,
-				QPoint(0, 0), GlobalPos, Qt::LeftButton, {Qt::LeftButton}, Qt::NoModifier));
-	});
+    QObject::connect(&DelayedAutoHideTimer, &QTimer::timeout, _this, [this]() {
+        auto GlobalPos = DelayedAutoHideTab->mapToGlobal(QPoint(0, 0));
+        qApp->sendEvent(DelayedAutoHideTab,
+                        new QMouseEvent(QEvent::MouseButtonPress, QPoint(0, 0),
+                                        GlobalPos, Qt::LeftButton,
+                                        {Qt::LeftButton}, Qt::NoModifier));
+    });
 }
 
 
@@ -528,14 +532,15 @@ void DockContainerWidgetPrivate::dropIntoAutoHideSideBar(CFloatingDockContainer*
 	auto NewDockAreas = FloatingWidget->findChildren<CDockAreaWidget*>(
 		QString(), Qt::FindChildrenRecursively);
 	int TabIndex = DockManager->containerOverlay()->tabIndexUnderCursor();
-	for (auto DockArea : NewDockAreas)
-	{
-		auto DockWidgets = DockArea->dockWidgets();
-		for (auto DockWidget : DockWidgets)
-		{
-			_this->createAndSetupAutoHideContainer(SideBarLocation, DockWidget, TabIndex++);
-		}
-	}
+    for (auto& DockArea : NewDockAreas)
+    {
+        auto DockWidgets = DockArea->dockWidgets();
+        for (auto& DockWidget : DockWidgets)
+        {
+            _this->createAndSetupAutoHideContainer(SideBarLocation, DockWidget,
+                                                   TabIndex++);
+        }
+    }
 }
 
 
@@ -793,19 +798,19 @@ void DockContainerWidgetPrivate::moveToAutoHideSideBar(QWidget* Widget, DockWidg
 		}
 		else
 		{
-			for (const auto DockWidget : DroppedDockArea->openedDockWidgets())
-			{
-				if (!DockWidget->features().testFlag(
-				    CDockWidget::DockWidgetPinnable))
-				{
-					continue;
-				}
+            for (auto& DockWidget : DroppedDockArea->openedDockWidgets())
+            {
+                if (!DockWidget->features().testFlag(
+                        CDockWidget::DockWidgetPinnable))
+                {
+                    continue;
+                }
 
-				_this->createAndSetupAutoHideContainer(SideBarLocation,
-				    DockWidget, TabIndex++);
-			}
-		}
-	}
+                _this->createAndSetupAutoHideContainer(SideBarLocation,
+                                                       DockWidget, TabIndex++);
+            }
+        }
+    }
 }
 
 
@@ -959,35 +964,35 @@ void DockContainerWidgetPrivate::saveChildNodesState(QXmlStreamWriter& s, QWidge
 			}
 
 			s.writeStartElement("Sizes");
-			for (auto Size : Splitter->sizes())
-			{
-				s.writeCharacters(QString::number(Size) + " ");
-			}
-			s.writeEndElement();
-		s.writeEndElement();
-	}
-	else
-	{
-		CDockAreaWidget* DockArea = qobject_cast<CDockAreaWidget*>(Widget);
-		if (DockArea)
-		{
-			DockArea->saveState(s);
-		}
-	}
+            for (auto& Size : Splitter->sizes())
+            {
+                s.writeCharacters(QString::number(Size) + " ");
+            }
+            s.writeEndElement();
+            s.writeEndElement();
+    }
+    else
+    {
+        CDockAreaWidget* DockArea = qobject_cast<CDockAreaWidget*>(Widget);
+        if (DockArea)
+        {
+            DockArea->saveState(s);
+        }
+    }
 }
 
 
 //============================================================================
 void DockContainerWidgetPrivate::saveAutoHideWidgetsState(QXmlStreamWriter& s)
 {
-	for (const auto sideTabBar : SideTabBarWidgets.values())
+    for (auto& sideTabBar : SideTabBarWidgets)
     {
-		if (!sideTabBar->count())
-		{
-			continue;
-		}
+        if (!sideTabBar->count())
+        {
+            continue;
+        }
 
-		sideTabBar->saveState(s);
+        sideTabBar->saveState(s);
     }
 }
 
@@ -1655,15 +1660,16 @@ QList<QPointer<CDockAreaWidget>> CDockContainerWidget::removeAllDockAreas()
 //============================================================================
 CDockAreaWidget* CDockContainerWidget::dockAreaAt(const QPoint& GlobalPos) const
 {
-	for (const auto& DockArea : d->DockAreas)
-	{
-		if (DockArea && DockArea->isVisible() && DockArea->rect().contains(DockArea->mapFromGlobal(GlobalPos)))
-		{
-			return DockArea;
-		}
-	}
+    for (auto& DockArea : d->DockAreas)
+    {
+        if (DockArea && DockArea->isVisible()
+            && DockArea->rect().contains(DockArea->mapFromGlobal(GlobalPos)))
+        {
+            return DockArea;
+        }
+    }
 
-	return nullptr;
+    return nullptr;
 }
 
 
@@ -1692,16 +1698,16 @@ int CDockContainerWidget::dockAreaCount() const
 int CDockContainerWidget::visibleDockAreaCount() const
 {
 	int Result = 0;
-	for (auto DockArea : d->DockAreas)
-	{
-		Result += (!DockArea || DockArea->isHidden()) ? 0 : 1;
-	}
+    for (auto& DockArea : d->DockAreas)
+    {
+        Result += (!DockArea || DockArea->isHidden()) ? 0 : 1;
+    }
 
-	return Result;
+    return Result;
 
-	// TODO Cache or precalculate this to speed it up because it is used during
-	// movement of floating widget
-	//return d->visibleDockAreaCount();
+    // TODO Cache or precalculate this to speed it up because it is used during
+    // movement of floating widget
+    // return d->visibleDockAreaCount();
 }
 
 
@@ -1756,32 +1762,34 @@ void CDockContainerWidget::dropFloatingWidget(CFloatingDockContainer* FloatingWi
 
     // Remove the auto hide widgets from the FloatingWidget and insert
 	// them into this widget
-	for (auto AutohideWidget : FloatingWidget->dockContainer()->autoHideWidgets())
-	{
-		auto SideBar = autoHideSideBar(AutohideWidget->sideBarLocation());
-		SideBar->addAutoHideWidget(AutohideWidget);
-	}
+    for (auto& AutohideWidget :
+         FloatingWidget->dockContainer()->autoHideWidgets())
+    {
+        auto SideBar = autoHideSideBar(AutohideWidget->sideBarLocation());
+        SideBar->addAutoHideWidget(AutohideWidget);
+    }
 
-	if (Dropped)
-	{ 
-		// Fix https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/351
-		FloatingWidget->finishDropOperation();
+    if (Dropped)
+    {
+        // Fix
+        // https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/351
+        FloatingWidget->finishDropOperation();
 
-		// If we dropped a floating widget with only one single dock widget, then we
-		// drop a top level widget that changes from floating to docked now
-		CDockWidget::emitTopLevelEventForWidget(SingleDroppedDockWidget, false);
+        // If we dropped a floating widget with only one single dock widget, then
+        // we drop a top level widget that changes from floating to docked now
+        CDockWidget::emitTopLevelEventForWidget(SingleDroppedDockWidget, false);
 
 		// If there was a top level widget before the drop, then it is not top
 		// level widget anymore
 		CDockWidget::emitTopLevelEventForWidget(SingleDockWidget, false);
-	}
+    }
 
-	window()->activateWindow();
-	if (SingleDroppedDockWidget)
-	{
-		d->DockManager->notifyWidgetOrAreaRelocation(SingleDroppedDockWidget);
-	}
-	d->DockManager->notifyFloatingWidgetDrop(FloatingWidget);
+    window()->activateWindow();
+    if (SingleDroppedDockWidget)
+    {
+        d->DockManager->notifyWidgetOrAreaRelocation(SingleDroppedDockWidget);
+    }
+    d->DockManager->notifyFloatingWidgetDrop(FloatingWidget);
 }
 
 
@@ -1816,15 +1824,15 @@ void CDockContainerWidget::dropWidget(QWidget* Widget, DockWidgetArea DropArea, 
 QList<CDockAreaWidget*> CDockContainerWidget::openedDockAreas() const
 {
 	QList<CDockAreaWidget*> Result;
-	for (auto DockArea : d->DockAreas)
-	{
-		if (DockArea && !DockArea->isHidden())
-		{
-			Result.append(DockArea);
-		}
-	}
+    for (auto& DockArea : d->DockAreas)
+    {
+        if (DockArea && !DockArea->isHidden())
+        {
+            Result.append(DockArea);
+        }
+    }
 
-	return Result;
+    return Result;
 }
 
 
@@ -1832,30 +1840,30 @@ QList<CDockAreaWidget*> CDockContainerWidget::openedDockAreas() const
 QList<CDockWidget*> CDockContainerWidget::openedDockWidgets() const
 {
 	QList<CDockWidget*> DockWidgetList;
-	for (auto DockArea : d->DockAreas)
-	{
-		if (DockArea && !DockArea->isHidden())
-		{
-			DockWidgetList.append(DockArea->openedDockWidgets());
-		}
-	}
+    for (auto& DockArea : d->DockAreas)
+    {
+        if (DockArea && !DockArea->isHidden())
+        {
+            DockWidgetList.append(DockArea->openedDockWidgets());
+        }
+    }
 
-	return DockWidgetList;
+    return DockWidgetList;
 }
 
 
 //============================================================================
 bool CDockContainerWidget::hasOpenDockAreas() const
 {
-	for (auto DockArea : d->DockAreas)
-	{
-		if (DockArea && !DockArea->isHidden())
-		{
-			return true;
-		}
-	}
+    for (auto& DockArea : d->DockAreas)
+    {
+        if (DockArea && !DockArea->isHidden())
+        {
+            return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
 
@@ -2072,16 +2080,16 @@ CDockAreaWidget* CDockContainerWidget::topLevelDockArea() const
 QList<CDockWidget*> CDockContainerWidget::dockWidgets() const
 {
 	QList<CDockWidget*> Result;
-    for (const auto& DockArea : d->DockAreas)
-	{
-		if (!DockArea)
-		{
+    for (auto& DockArea : d->DockAreas)
+    {
+        if (!DockArea)
+        {
 			continue;
 		}
 		Result.append(DockArea->dockWidgets());
-	}
+    }
 
-	return Result;
+    return Result;
 }
 
 //============================================================================
@@ -2108,16 +2116,16 @@ void CDockContainerWidget::removeAutoHideWidget(CAutoHideDockContainer* Autohide
 CDockWidget::DockWidgetFeatures CDockContainerWidget::features() const
 {
 	CDockWidget::DockWidgetFeatures Features(CDockWidget::AllDockWidgetFeatures);
-    for (const auto& DockArea : d->DockAreas)
-	{
-		if (!DockArea)
+    for (auto& DockArea : d->DockAreas)
+    {
+        if (!DockArea)
 		{
 			continue;
 		}
 		Features &= DockArea->features();
-	}
+    }
 
-	return Features;
+    return Features;
 }
 
 
@@ -2131,8 +2139,8 @@ CFloatingDockContainer* CDockContainerWidget::floatingWidget() const
 //============================================================================
 void CDockContainerWidget::closeOtherAreas(CDockAreaWidget* KeepOpenArea)
 {
-    for (const auto& DockArea : d->DockAreas)
-	{
+    for (auto& DockArea : d->DockAreas)
+    {
 		if (!DockArea || DockArea == KeepOpenArea)
 		{
 			continue;

--- a/src/DockFocusController.cpp
+++ b/src/DockFocusController.cpp
@@ -11,9 +11,6 @@
 #include <AutoHideTab.h>
 #include "DockFocusController.h"
 
-#include <algorithm>
-#include <iostream>
-
 #include <QPointer>
 #include <QApplication>
 #include <QAbstractButton>
@@ -226,11 +223,12 @@ CDockFocusController::CDockFocusController(CDockManager* DockManager) :
 	d(new DockFocusControllerPrivate(this))
 {
 	d->DockManager = DockManager;
-	connect(QApplication::instance(), SIGNAL(focusChanged(QWidget*, QWidget*)),
-			this, SLOT(onApplicationFocusChanged(QWidget*, QWidget*)));
-	connect(QApplication::instance(), SIGNAL(focusWindowChanged(QWindow*)),
-			this, SLOT(onFocusWindowChanged(QWindow*)));
-	connect(d->DockManager, SIGNAL(stateRestored()), SLOT(onStateRestored()));
+    connect(qApp, &QApplication::focusChanged, this,
+            &CDockFocusController::onApplicationFocusChanged);
+    connect(qApp, &QApplication::focusWindowChanged, this,
+            &CDockFocusController::onFocusWindowChanged);
+    connect(d->DockManager, &CDockManager::stateRestored, this,
+            &CDockFocusController::onStateRestored);
 }
 
 //============================================================================
@@ -260,7 +258,8 @@ void CDockFocusController::onFocusWindowChanged(QWindow *focusWindow)
 		return;
 	}
 
-	d->updateDockWidgetFocus(DockWidget);
+    if(DockWidget->dockManager() == d->DockManager)
+        d->updateDockWidgetFocus(DockWidget);
 }
 
 
@@ -298,10 +297,11 @@ void CDockFocusController::onApplicationFocusChanged(QWidget* focusedOld, QWidge
     if (!DockWidget || DockWidget->tabWidget()->isHidden())
 	{
     	return;
-	}
+    }
 #endif
 
-	d->updateDockWidgetFocus(DockWidget);
+    if(DockWidget->dockManager() == d->DockManager)
+        d->updateDockWidgetFocus(DockWidget);
 }
 
 
@@ -309,7 +309,7 @@ void CDockFocusController::onApplicationFocusChanged(QWidget* focusedOld, QWidge
 void CDockFocusController::setDockWidgetTabFocused(CDockWidgetTab* Tab)
 {
 	auto DockWidget = Tab->dockWidget();
-	if (DockWidget)
+    if (DockWidget && DockWidget->dockManager() == d->DockManager)
 	{
 		d->updateDockWidgetFocus(DockWidget);
 	}
@@ -327,7 +327,8 @@ void CDockFocusController::clearDockWidgetFocus(CDockWidget* dockWidget)
 //===========================================================================
 void CDockFocusController::setDockWidgetFocused(CDockWidget* focusedNow)
 {
-	d->updateDockWidgetFocus(focusedNow);
+    if(focusedNow->dockManager() == d->DockManager)
+        d->updateDockWidgetFocus(focusedNow);
 }
 
 

--- a/src/DockFocusController.h
+++ b/src/DockFocusController.h
@@ -96,7 +96,7 @@ public Q_SLOTS:
 	/**
 	 * Request a focus change to the given dock widget
 	 */
-	void setDockWidgetFocused(CDockWidget* focusedNow);
+    void setDockWidgetFocused(ads::CDockWidget* focusedNow);
 }; // class DockFocusController
 }
  // namespace ads

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -33,7 +33,6 @@
 #include "DockManager.h"
 
 #include <algorithm>
-#include <iostream>
 
 #include <QMainWindow>
 #include <QList>
@@ -95,11 +94,16 @@ enum eStateFileVersion
 	CurrentVersion = Version1//!< CurrentVersion
 };
 
-static CDockManager::ConfigFlags StaticConfigFlags = CDockManager::DefaultNonOpaqueConfig;
-static CDockManager::AutoHideFlags StaticAutoHideConfigFlags; // auto hide feature is disabled by default
-static QVector<QVariant> StaticConfigParams(CDockManager::ConfigParamCount);
+Q_GLOBAL_STATIC_WITH_ARGS(CDockManager::ConfigFlags, StaticConfigFlags,
+                          (CDockManager::DefaultNonOpaqueConfig));
+// auto hide feature is disabled by default
+Q_GLOBAL_STATIC(CDockManager::AutoHideFlags, StaticAutoHideConfigFlags)
 
-static QString FloatingContainersTitle;
+using CONFIG_PARAMS_CONTAINER = QVector<QVariant>;
+Q_GLOBAL_STATIC_WITH_ARGS(CONFIG_PARAMS_CONTAINER, StaticConfigParams,
+                          (CDockManager::ConfigParamCount));
+
+Q_GLOBAL_STATIC(QString, FloatingContainersTitle);
 
 /**
  * Private data class of CDockManager class (pimpl)
@@ -157,32 +161,32 @@ struct DockManagerPrivate
 	void hideFloatingWidgets()
 	{
 		// Hide updates of floating widgets from user
-		for (auto FloatingWidget : FloatingWidgets)
-		{
-			if (FloatingWidget)
-			{
-			  FloatingWidget->hide();
-			}
-		}
-	}
+        for (auto& FloatingWidget : FloatingWidgets)
+        {
+            if (FloatingWidget)
+            {
+                FloatingWidget->hide();
+            }
+        }
+    }
 
-	void markDockWidgetsDirty()
-	{
-		for (auto DockWidget : DockWidgetsMap)
-		{
-			DockWidget->setProperty(internal::DirtyProperty, true);
-		}
-	}
+    void markDockWidgetsDirty()
+    {
+        for (auto& DockWidget : DockWidgetsMap)
+        {
+            DockWidget->setProperty(internal::DirtyProperty, true);
+        }
+    }
 
-	/**
-	 * Restores the container with the given index
-	 */
-	bool restoreContainer(int Index, CDockingStateReader& stream, bool Testing);
+    /**
+     * Restores the container with the given index
+     */
+    bool restoreContainer(int Index, CDockingStateReader& stream, bool Testing);
 
-	/**
-	 * Loads the stylesheet
-	 */
-	void loadStylesheet();
+    /**
+     * Loads the stylesheet
+     */
+    void loadStylesheet();
 
 	/**
 	 * Adds action to menu - optionally in sorted order
@@ -360,7 +364,7 @@ void DockManagerPrivate::restoreDockWidgetsOpenState()
     // function are invisible to the user now and have no assigned dock area
     // They do not belong to any dock container, until the user toggles the
     // toggle view action the next time
-    for (auto DockWidget : DockWidgetsMap)
+    for (auto& DockWidget : DockWidgetsMap)
     {
     	if (DockWidget->property(internal::DirtyProperty).toBool())
     	{
@@ -388,7 +392,7 @@ void DockManagerPrivate::restoreDockAreasIndices()
     // The dock areas because the previous toggleView() action has changed
     // the dock area index
     int Count = 0;
-    for (auto DockContainer : Containers)
+    for (auto& DockContainer : Containers)
     {
     	Count++;
     	for (int i = 0; i < DockContainer->dockAreaCount(); ++i)
@@ -423,7 +427,7 @@ void DockManagerPrivate::emitTopLevelEvents()
 {
     // Finally we need to send the topLevelChanged() signals for all dock
     // widgets if top level changed
-    for (auto DockContainer : Containers)
+    for (auto& DockContainer : Containers)
     {
     	CDockWidget* TopLevelDockWidget = DockContainer->topLevelDockWidget();
     	if (TopLevelDockWidget)
@@ -435,12 +439,12 @@ void DockManagerPrivate::emitTopLevelEvents()
 			for (int i = 0; i < DockContainer->dockAreaCount(); ++i)
 			{
 				auto DockArea = DockContainer->dockArea(i);
-				for (auto DockWidget : DockArea->dockWidgets())
-				{
-					DockWidget->emitTopLevelChanged(false);
-				}
-			}
-    	}
+                for (auto& DockWidget : DockArea->dockWidgets())
+                {
+                    DockWidget->emitTopLevelChanged(false);
+                }
+            }
+        }
     }
 }
 
@@ -530,28 +534,29 @@ CDockManager::CDockManager(QWidget *parent) :
 	window()->installEventFilter(this);
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    connect(qApp, &QApplication::focusWindowChanged, [this](QWindow* focusWindow)
-    {
-        if (!focusWindow)
-        {
-            return;
-        }
+    connect(qApp, &QApplication::focusWindowChanged, this,
+            [this](QWindow* focusWindow) {
+                if (!focusWindow)
+                {
+                    return;
+                }
 
-        // bring the main application window that hosts the dock manager and all floating
-        // widgets in front of any other application
-        this->raise();
-        for (auto FloatingWidget : d->FloatingWidgets)
-        {
-            if (FloatingWidget)
-            {
-                FloatingWidget->raise();
-            }
-        }
+                // bring the main application window that hosts the dock manager
+                // and all floating widgets in front of any other application
+                this->raise();
+                for (auto& FloatingWidget : d->FloatingWidgets)
+                {
+                    if (FloatingWidget)
+                    {
+                        FloatingWidget->raise();
+                    }
+                }
 
-        // ensure that the dragged floating window is in front of the main application window
-        // and any other floating widget - this will also ensure that modal dialogs come to foreground
-        focusWindow->raise();
-    });
+                // ensure that the dragged floating window is in front of the main
+                // application window and any other floating widget - this will
+                // also ensure that modal dialogs come to foreground
+                focusWindow->raise();
+            });
 #endif
 }
 
@@ -564,37 +569,33 @@ CDockManager::~CDockManager()
 	{
 		areas.push_back( dockArea(i) );
 	}
-	for ( auto area : areas )
-	{
-		if (!area || area->dockManager() != this) continue;
+    for (auto& area : areas)
+    {
+        if (!area || area->dockManager() != this)
+            continue;
 
-		// QPointer delete safety - just in case some dock widget in destruction
-		// deletes another related/twin or child dock widget.
-		std::vector<QPointer<QWidget>> deleteWidgets;
-		for ( auto widget : area->dockWidgets() )
-		{
-			deleteWidgets.push_back(widget);
-		}
-		for ( auto ptrWdg : deleteWidgets)
-		{
-			delete ptrWdg;
-		}
-	}
+        // QPointer delete safety - just in case some dock widget in destruction
+        // deletes another related/twin or child dock widget.
+        std::vector<QPointer<QWidget>> deleteWidgets;
+        for (auto& widget : area->dockWidgets())
+        {
+            deleteWidgets.push_back(widget);
+        }
+        qDeleteAll(deleteWidgets);
+    }
 
-	auto FloatingWidgets = d->FloatingWidgets;
-	for (auto FloatingWidget : FloatingWidgets)
-	{
-		FloatingWidget->deleteContent();
-		delete FloatingWidget;
-	}
+    auto FloatingWidgets = d->FloatingWidgets;
+    for (auto FloatingWidget : FloatingWidgets)
+    {
+        FloatingWidget->deleteContent();
+        delete FloatingWidget;
+    }
 
-	// Delete Dock Widgets before Areas so widgets can access them late (like dtor)
-	for ( auto area : areas )
-	{
-		delete area;
-	}
+    // Delete Dock Widgets before Areas so widgets can access them late (like
+    // dtor)
+    qDeleteAll(areas);
 
-	delete d;
+    delete d;
 }
 
 
@@ -636,15 +637,16 @@ bool CDockManager::eventFilter(QObject *obj, QEvent *e)
 	// Window always on top of the MainWindow.
 	if (e->type() == QEvent::WindowActivate)
 	{
-        for (auto _window : d->FloatingWidgets)
-		{
-			if (!_window->isVisible() || window()->isMinimized())
-			{
-				continue;
-			}
-			// setWindowFlags(Qt::WindowStaysOnTopHint) will hide the window and thus requires a show call.
-			// This then leads to flickering and a nasty endless loop (also buggy behaviour on Ubuntu).
-			// So we just do it ourself.
+        for (auto& _window : d->FloatingWidgets)
+        {
+            if (!_window->isVisible() || window()->isMinimized())
+            {
+                continue;
+            }
+            // setWindowFlags(Qt::WindowStaysOnTopHint) will hide the window and
+            // thus requires a show call. This then leads to flickering and a
+            // nasty endless loop (also buggy behaviour on Ubuntu). So we just do
+            // it ourself.
             if(QGuiApplication::platformName() == QLatin1String("xcb"))
 			{
 				internal::xcb_update_prop(true, _window->window()->winId(),
@@ -655,15 +657,15 @@ bool CDockManager::eventFilter(QObject *obj, QEvent *e)
                     _window->setWindowFlag(Qt::WindowStaysOnTopHint, true);
 			}
         }
-	}
-	else if (e->type() == QEvent::WindowDeactivate)
-	{
-        for (auto _window : d->FloatingWidgets)
-		{
-			if (!_window->isVisible() || window()->isMinimized())
-			{
-				continue;
-			}
+    }
+    else if (e->type() == QEvent::WindowDeactivate)
+    {
+        for (auto& _window : d->FloatingWidgets)
+        {
+            if (!_window->isVisible() || window()->isMinimized())
+            {
+                continue;
+            }
 
             if(QGuiApplication::platformName() == QLatin1String("xcb"))
 			{
@@ -675,34 +677,39 @@ bool CDockManager::eventFilter(QObject *obj, QEvent *e)
 				_window->setWindowFlag(Qt::WindowStaysOnTopHint, false);
 			}
 			_window->raise();
-		}
-	}
+        }
+    }
 
-	// Sync minimize with MainWindow
-	if (e->type() == QEvent::WindowStateChange)
-	{
-        for (auto _window : d->FloatingWidgets)
-		{
-			if (! _window->isVisible())
-			{
-				continue;
-			}
+    // Sync minimize with MainWindow
+    if (e->type() == QEvent::WindowStateChange)
+    {
+        for (auto& _window : d->FloatingWidgets)
+        {
+            if (!_window->isVisible())
+            {
+                continue;
+            }
 
-			if (window()->isMinimized())
-			{
-				_window->showMinimized();
-			}
-			else
-			{
-				_window->setWindowState(_window->windowState() & (~Qt::WindowMinimized));
-			}
-		}
-		if (!window()->isMinimized())
-		{
-			QApplication::setActiveWindow(window());
-		}
-	}
-	return Super::eventFilter(obj, e);
+            if (window()->isMinimized())
+            {
+                _window->showMinimized();
+            }
+            else
+            {
+                _window->setWindowState(_window->windowState()
+                                        & (~Qt::WindowMinimized));
+            }
+        }
+        if (!window()->isMinimized())
+        {
+#    if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            window()->activateWindow();
+#    else
+            QApplication::setActiveWindow(window());
+#    endif
+        }
+    }
+    return Super::eventFilter(obj, e);
 }
 #else
 //============================================================================
@@ -825,16 +832,17 @@ QByteArray CDockManager::saveState(int version) const
 		{
 			s.writeAttribute("CentralWidget", d->CentralWidget->objectName());
 		}
-		for (auto Container : d->Containers)
-		{
-			Container->saveState(s);
-		}
+        for (auto& Container : d->Containers)
+        {
+            Container->saveState(s);
+        }
 
-		s.writeEndElement();
-    s.writeEndDocument();
+        s.writeEndElement();
+        s.writeEndDocument();
 
-    return ConfigFlags.testFlag(XmlCompressionEnabled)
-    	? qCompress(xmldata, 9) : xmldata;
+        return ConfigFlags.testFlag(XmlCompressionEnabled) ?
+                   qCompress(xmldata, 9) :
+                   xmldata;
 }
 
 
@@ -912,16 +920,16 @@ void CDockManager::showEvent(QShowEvent *event)
 		return;
 	}
 
-	for (auto FloatingWidget : d->UninitializedFloatingWidgets)
-	{
-		// Check, if someone closed a floating dock widget before the dock
-		// manager is shown
-		if (FloatingWidget->dockContainer()->hasOpenDockAreas())
-		{
-			FloatingWidget->show();
-		}
-	}
-	d->UninitializedFloatingWidgets.clear();
+    for (auto& FloatingWidget : d->UninitializedFloatingWidgets)
+    {
+        // Check, if someone closed a floating dock widget before the dock
+        // manager is shown
+        if (FloatingWidget->dockContainer()->hasOpenDockAreas())
+        {
+            FloatingWidget->show();
+        }
+    }
+    d->UninitializedFloatingWidgets.clear();
 }
 
 
@@ -934,30 +942,32 @@ void CDockManager::restoreHiddenFloatingWidgets()
 	}
 
 	// Restore floating widgets that were hidden upon hideManagerAndFloatingWidgets
-	for (auto FloatingWidget : d->HiddenFloatingWidgets)
-	{
-		bool hasDockWidgetVisible = false;
+    for (auto& FloatingWidget : d->HiddenFloatingWidgets)
+    {
+        bool hasDockWidgetVisible = false;
 
-		// Needed to prevent CFloatingDockContainer being shown empty
-		// Could make sense to move this to CFloatingDockContainer::showEvent(QShowEvent *event)
-		// if experiencing CFloatingDockContainer being shown empty in other situations, but let's keep
-		// it here for now to make sure changes to fix Issue #380 does not impact existing behaviours
-		for (auto dockWidget : FloatingWidget->dockWidgets())
-		{
-			if (dockWidget->toggleViewAction()->isChecked())
-			{
-				dockWidget->toggleView(true);
-				hasDockWidgetVisible = true;
-			}
-		}
+        // Needed to prevent CFloatingDockContainer being shown empty
+        // Could make sense to move this to
+        // CFloatingDockContainer::showEvent(QShowEvent *event) if experiencing
+        // CFloatingDockContainer being shown empty in other situations, but let's
+        // keep it here for now to make sure changes to fix Issue #380 does not
+        // impact existing behaviours
+        for (auto& dockWidget : FloatingWidget->dockWidgets())
+        {
+            if (dockWidget->toggleViewAction()->isChecked())
+            {
+                dockWidget->toggleView(true);
+                hasDockWidgetVisible = true;
+            }
+        }
 
-		if (hasDockWidgetVisible)
-		{
-			FloatingWidget->show();
-		}
-	}
+        if (hasDockWidgetVisible)
+        {
+            FloatingWidget->show();
+        }
+    }
 
-	d->HiddenFloatingWidgets.clear();
+    d->HiddenFloatingWidgets.clear();
 }
 
 //============================================================================
@@ -1253,40 +1263,40 @@ int CDockManager::startDragDistance()
 //===========================================================================
 CDockManager::ConfigFlags CDockManager::configFlags()
 {
-	return StaticConfigFlags;
+    return *StaticConfigFlags;
 }
 
 CDockManager::AutoHideFlags CDockManager::autoHideConfigFlags()
 {
-	return StaticAutoHideConfigFlags;
+    return *StaticAutoHideConfigFlags;
 }
 
 
 //===========================================================================
 void CDockManager::setConfigFlags(const ConfigFlags Flags)
 {
-	StaticConfigFlags = Flags;
+    *StaticConfigFlags = Flags;
 }
 
 
 //===========================================================================
 void CDockManager::setAutoHideConfigFlags(const AutoHideFlags Flags)
 {
-	StaticAutoHideConfigFlags = Flags;
+    *StaticAutoHideConfigFlags = Flags;
 }
 
 
 //===========================================================================
 void CDockManager::setConfigFlag(eConfigFlag Flag, bool On)
 {
-	internal::setFlag(StaticConfigFlags, Flag, On);
+    internal::setFlag(*StaticConfigFlags, Flag, On);
 }
 
 
 //===========================================================================
 void CDockManager::setAutoHideConfigFlag(eAutoHideFlag Flag, bool On)
 {
-	internal::setFlag(StaticAutoHideConfigFlags, Flag, On);
+    internal::setFlag(*StaticAutoHideConfigFlags, Flag, On);
 }
 
 //===========================================================================
@@ -1347,30 +1357,31 @@ void CDockManager::hideManagerAndFloatingWidgets()
 
 	d->HiddenFloatingWidgets.clear();
 	// Hide updates of floating widgets from user
-	for (auto FloatingWidget : d->FloatingWidgets)
-	{
-		if ( FloatingWidget->isVisible() )
-		{
-			QList<CDockWidget*> VisibleWidgets;
-			for ( auto dockWidget : FloatingWidget->dockWidgets() )
-			{
-				if ( dockWidget->toggleViewAction()->isChecked() )
-					VisibleWidgets.push_back( dockWidget );
-			}
+    for (auto& FloatingWidget : d->FloatingWidgets)
+    {
+        if (FloatingWidget->isVisible())
+        {
+            QList<CDockWidget*> VisibleWidgets;
+            for (auto& dockWidget : FloatingWidget->dockWidgets())
+            {
+                if (dockWidget->toggleViewAction()->isChecked())
+                    VisibleWidgets.push_back(dockWidget);
+            }
 
-			// save as floating widget to be shown when CDockManager will be shown back
-			d->HiddenFloatingWidgets.push_back( FloatingWidget );
-			FloatingWidget->hide();
+            // save as floating widget to be shown when CDockManager will be shown
+            // back
+            d->HiddenFloatingWidgets.push_back(FloatingWidget);
+            FloatingWidget->hide();
 
-			// hiding floating widget automatically marked contained CDockWidgets as hidden
-			// but they must remain marked as visible as we want them to be restored visible
-			// when CDockManager will be shown back
-			for ( auto dockWidget : VisibleWidgets )
-			{
-				dockWidget->toggleViewAction()->setChecked(true);
-			}
-		}
-		}
+            // hiding floating widget automatically marked contained CDockWidgets
+            // as hidden but they must remain marked as visible as we want them to
+            // be restored visible when CDockManager will be shown back
+            for (auto dockWidget : VisibleWidgets)
+            {
+                dockWidget->toggleViewAction()->setChecked(true);
+            }
+        }
+    }
 }
 
 //===========================================================================
@@ -1425,17 +1436,17 @@ CDockFocusController* CDockManager::dockFocusController() const
 //===========================================================================
 void CDockManager::setFloatingContainersTitle(const QString& Title)
 {
-	FloatingContainersTitle = Title;
+    *FloatingContainersTitle = Title;
 }
 
 
 //===========================================================================
 QString CDockManager::floatingContainersTitle()
 {
-	if (FloatingContainersTitle.isEmpty())
-		return qApp->applicationDisplayName();
+    if (FloatingContainersTitle->isEmpty())
+        return qApp->applicationDisplayName();
 
-	return FloatingContainersTitle;
+    return *FloatingContainersTitle;
 }
 
 
@@ -1508,7 +1519,7 @@ void CDockManager::lockDockWidgetFeaturesGlobally(CDockWidget::DockWidgetFeature
 	d->LockedDockWidgetFeatures = Value;
 	// Call the notifyFeaturesChanged() function for all dock widgets to update
 	// the state of the close and detach buttons
-    for (auto DockWidget : d->DockWidgetsMap)
+    for (auto& DockWidget : d->DockWidgetsMap)
     {
     	DockWidget->notifyFeaturesChanged();
     }
@@ -1525,14 +1536,22 @@ CDockWidget::DockWidgetFeatures CDockManager::globallyLockedDockWidgetFeatures()
 //===========================================================================
 void CDockManager::setConfigParam(CDockManager::eConfigParam Param, QVariant Value)
 {
-	StaticConfigParams[Param] = Value;
+    (*StaticConfigParams)[Param] = Value;
 }
 
 
 //===========================================================================
 QVariant CDockManager::configParam(eConfigParam Param, QVariant Default)
 {
-	return StaticConfigParams[Param].isValid() ? StaticConfigParams[Param] : Default;
+    auto configParam = (*StaticConfigParams)[Param];
+    if (configParam.isValid())
+    {
+        return configParam;
+    }
+    else
+    {
+        return Default;
+    }
 }
 
 

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -762,7 +762,7 @@ public Q_SLOTS:
 	 * This function only has an effect, if the flag CDockManager::FocusStyling
 	 * is enabled
 	 */
-	void setDockWidgetFocused(CDockWidget* DockWidget);
+    void setDockWidgetFocused(ads::CDockWidget* DockWidget);
 
     /**
      * hide CDockManager and all floating widgets (See Issue #380). Calling regular QWidget::hide()

--- a/src/DockOverlay.cpp
+++ b/src/DockOverlay.cpp
@@ -43,8 +43,6 @@
 #include "DockManager.h"
 #include "DockAreaTabBar.h"
 
-#include <iostream>
-
 namespace ads
 {
 static const int AutoHideAreaWidth = 32;
@@ -789,8 +787,8 @@ void CDockOverlayCross::updateOverlayIcons()
 		return;
 	}
 
-	for (auto Widget : d->DropIndicatorWidgets)
-	{
+    for (auto& Widget : d->DropIndicatorWidgets)
+    {
 		d->updateDropIndicatorIcon(Widget);
 	}
 #if QT_VERSION >= 0x050600
@@ -957,8 +955,8 @@ void CDockOverlayCross::setIconColors(const QString& Colors)
     auto SkipEmptyParts = Qt::SkipEmptyParts;
 #endif
     auto ColorList = Colors.split(' ', SkipEmptyParts);
-	for (const auto& ColorListEntry : ColorList)
-	{
+    for (auto& ColorListEntry : ColorList)
+    {
         auto ComponentColor = ColorListEntry.split('=', SkipEmptyParts);
 		int Component = ColorCompenentStringMap.value(ComponentColor[0], -1);
 		if (Component < 0)

--- a/src/DockSplitter.cpp
+++ b/src/DockSplitter.cpp
@@ -105,7 +105,7 @@ QWidget* CDockSplitter::lastWidget() const
 //============================================================================
 bool CDockSplitter::isResizingWithContainer() const
 {
-    for (auto area : findChildren<CDockAreaWidget*>())
+    for (auto& area : findChildren<CDockAreaWidget*>())
     {
         if(area->isCentralWidgetArea())
         {

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -34,8 +34,6 @@
 #include "DockWidgetTab.h"
 #include "DockWidget.h"
 
-#include <iostream>
-
 #include <QBoxLayout>
 #include <QAction>
 #include <QSplitter>
@@ -287,16 +285,16 @@ void DockWidgetPrivate::closeAutoHideDockWidgetsIfNeeded()
 		return;
 	}
 
-	for (auto autoHideWidget : DockContainer->autoHideWidgets())
-	{
-		auto DockWidget = autoHideWidget->dockWidget();
-		if (DockWidget == _this)
-		{
-			continue;
-		}
+    for (auto& autoHideWidget : DockContainer->autoHideWidgets())
+    {
+        auto DockWidget = autoHideWidget->dockWidget();
+        if (DockWidget == _this)
+        {
+            continue;
+        }
 
-		DockWidget->toggleView(false);
-	}
+        DockWidget->toggleView(false);
+    }
 }
 
 
@@ -309,7 +307,8 @@ void DockWidgetPrivate::setupToolBar()
 	ToolBar->setIconSize(QSize(16, 16));
 	ToolBar->toggleViewAction()->setEnabled(false);
 	ToolBar->toggleViewAction()->setVisible(false);
-	_this->connect(_this, SIGNAL(topLevelChanged(bool)), SLOT(setToolbarFloatingStyle(bool)));
+    QObject::connect(_this, &CDockWidget::topLevelChanged, _this,
+                     &CDockWidget::setToolbarFloatingStyle);
 }
 
 
@@ -388,12 +387,12 @@ CDockWidget::CDockWidget(CDockManager *manager, const QString &title, QWidget* p
 
 	d->ToggleViewAction = new QAction(title, this);
 	d->ToggleViewAction->setCheckable(true);
-	connect(d->ToggleViewAction, SIGNAL(triggered(bool)), this,
-		SLOT(toggleView(bool)));
-	setToolbarFloatingStyle(false);
+    connect(d->ToggleViewAction, &QAction::triggered, this,
+            &CDockWidget::toggleView);
+    setToolbarFloatingStyle(false);
 
-	if (CDockManager::testConfigFlag(CDockManager::FocusHighlighting))
-	{
+    if (CDockManager::testConfigFlag(CDockManager::FocusHighlighting))
+    {
 		setFocusPolicy(Qt::ClickFocus);
 	}
 }
@@ -971,8 +970,9 @@ void CDockWidget::setToolBar(QToolBar* ToolBar)
 
 	d->ToolBar = ToolBar;
 	d->Layout->insertWidget(0, d->ToolBar);
-	this->connect(this, SIGNAL(topLevelChanged(bool)), SLOT(setToolbarFloatingStyle(bool)));
-	setToolbarFloatingStyle(isFloating());
+    connect(this, &CDockWidget::topLevelChanged, this,
+            &CDockWidget::setToolbarFloatingStyle);
+    setToolbarFloatingStyle(isFloating());
 }
 
 

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -677,14 +677,14 @@ public Q_SLOTS:
 	 * Sets the dock widget into auto hide mode if this feature is enabled
 	 * via CDockManager::setAutoHideFlags(CDockManager::AutoHideFeatureEnabled)
 	 */
-	void setAutoHide(bool Enable, SideBarLocation Location = SideBarNone, int TabIndex = -1);
+    void setAutoHide(bool Enable, ads::SideBarLocation Location = SideBarNone,
+                     int TabIndex = -1);
 
-	/**
+    /**
 	 * Switches the dock widget to auto hide mode or vice versa depending on its
 	 * current state.
 	 */
-	void toggleAutoHide(SideBarLocation Location = SideBarNone);
-
+    void toggleAutoHide(ads::SideBarLocation Location = SideBarNone);
 
 Q_SIGNALS:
     /**

--- a/src/DockWidgetTab.cpp
+++ b/src/DockWidgetTab.cpp
@@ -169,19 +169,17 @@ struct DockWidgetTabPrivate
 		else
 		{
 			auto w = new CFloatingDragPreview(Widget);
-			_this->connect(w, &CFloatingDragPreview::draggingCanceled, [this]()
-			{
-				DragState = DraggingInactive;
-			});
-			return w;
-		}
-	}
+            QObject::connect(w, &CFloatingDragPreview::draggingCanceled, _this,
+                             [this]() { DragState = DraggingInactive; });
+            return w;
+        }
+    }
 
-	/**
-	 * Saves the drag start position in global and local coordinates
-	 */
-	void saveDragStartMousePosition(const QPoint& GlobalPos)
-	{
+    /**
+     * Saves the drag start position in global and local coordinates
+     */
+    void saveDragStartMousePosition(const QPoint& GlobalPos)
+    {
 		GlobalDragStartMousePosition = GlobalPos;
 		DragStartMousePosition = _this->mapFromGlobal(GlobalPos);
 	}
@@ -254,22 +252,24 @@ void DockWidgetTabPrivate::createLayout()
 	TitleLabel->setText(DockWidget->windowTitle());
 	TitleLabel->setObjectName("dockWidgetTabLabel");
 	TitleLabel->setAlignment(Qt::AlignCenter);
-	_this->connect(TitleLabel, SIGNAL(elidedChanged(bool)), SIGNAL(elidedChanged(bool)));
+    QObject::connect(TitleLabel, &tTabLabel::elidedChanged, _this,
+                     &CDockWidgetTab::elidedChanged);
 
-
-	CloseButton = createCloseButton();
-	CloseButton->setObjectName("tabCloseButton");
-	internal::setButtonIcon(CloseButton, QStyle::SP_TitleBarCloseButton, TabCloseIcon);
+    CloseButton = createCloseButton();
+    CloseButton->setObjectName("tabCloseButton");
+    internal::setButtonIcon(CloseButton, QStyle::SP_TitleBarCloseButton,
+                            TabCloseIcon);
     CloseButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     CloseButton->setFocusPolicy(Qt::NoFocus);
     updateCloseButtonSizePolicy();
 	internal::setToolTip(CloseButton, QObject::tr("Close Tab"));
-	_this->connect(CloseButton, SIGNAL(clicked()), SIGNAL(closeRequested()));
+    QObject::connect(CloseButton, &QAbstractButton::clicked, _this,
+                     &CDockWidgetTab::closeRequested);
 
-	QFontMetrics fm(TitleLabel->font());
-	int Spacing = qRound(fm.height() / 4.0);
+    QFontMetrics fm(TitleLabel->font());
+    int Spacing = qRound(fm.height() / 4.0);
 
-	// Fill the layout
+    // Fill the layout
 	QBoxLayout* Layout = new QBoxLayout(QBoxLayout::LeftToRight);
 	Layout->setContentsMargins(2 * Spacing,0,0,0);
 	Layout->setSpacing(0);
@@ -834,8 +834,12 @@ QSize CDockWidgetTab::iconSize() const
 //============================================================================
 void CDockWidgetTab::setIconSize(const QSize& Size)
 {
-	d->IconSize = Size;
-	d->updateIcon();
+    if (d->IconSize != Size)
+    {
+        d->IconSize = Size;
+        d->updateIcon();
+        Q_EMIT iconSizeChanged();
+    }
 }
 
 } // namespace ads

--- a/src/DockWidgetTab.h
+++ b/src/DockWidgetTab.h
@@ -53,7 +53,8 @@ class ADS_EXPORT CDockWidgetTab : public QFrame
 {
 	Q_OBJECT
 	Q_PROPERTY(bool activeTab READ isActiveTab WRITE setActiveTab NOTIFY activeTabChanged)
-	Q_PROPERTY(QSize iconSize READ iconSize WRITE setIconSize)
+    Q_PROPERTY(
+        QSize iconSize READ iconSize WRITE setIconSize NOTIFY iconSizeChanged)
 
 private:
 	DockWidgetTabPrivate* d; ///< private data (pimpl)
@@ -205,8 +206,9 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void activeTabChanged();
-	void clicked();
-	void closeRequested();
+    void iconSizeChanged();
+    void clicked();
+    void closeRequested();
 	void closeOtherTabsRequested();
 	void moved(const QPoint& GlobalPos);
 	void elidedChanged(bool elided);

--- a/src/FloatingDragPreview.cpp
+++ b/src/FloatingDragPreview.cpp
@@ -10,7 +10,6 @@
 //============================================================================
 #include <AutoHideDockContainer.h>
 #include "FloatingDragPreview.h"
-#include <iostream>
 
 #include <QEvent>
 #include <QApplication>
@@ -310,12 +309,12 @@ CFloatingDragPreview::CFloatingDragPreview(QWidget* Content, QWidget* parent) :
 		Content->render(&d->ContentPreviewPixmap);
 	}
 
-	connect(qApp, SIGNAL(applicationStateChanged(Qt::ApplicationState)),
-		SLOT(onApplicationStateChanged(Qt::ApplicationState)));
+    connect(qApp, &QApplication::applicationStateChanged, this,
+            &CFloatingDragPreview::onApplicationStateChanged);
 
-	// The only safe way to receive escape key presses is to install an event
-	// filter for the application object
-	qApp->installEventFilter(this);
+    // The only safe way to receive escape key presses is to install an event
+    // filter for the application object
+    qApp->installEventFilter(this);
 }
 
 
@@ -489,10 +488,10 @@ void CFloatingDragPreview::onApplicationStateChanged(Qt::ApplicationState state)
 {
 	if (state != Qt::ApplicationActive)
 	{
-		disconnect(qApp, SIGNAL(applicationStateChanged(Qt::ApplicationState)),
-			this, SLOT(onApplicationStateChanged(Qt::ApplicationState)));
-		d->cancelDragging();
-	}
+        disconnect(qApp, &QApplication::applicationStateChanged, this,
+                   &CFloatingDragPreview::onApplicationStateChanged);
+        d->cancelDragging();
+    }
 }
 
 

--- a/src/ResizeHandle.cpp
+++ b/src/ResizeHandle.cpp
@@ -311,7 +311,11 @@ void CResizeHandle::setMaxResizeSize(int MaxSize)
 //============================================================================
 void CResizeHandle::setOpaqueResize(bool opaque)
 {
-	d->OpaqueResize = opaque;
+    if (d->OpaqueResize != opaque)
+    {
+        d->OpaqueResize = opaque;
+        Q_EMIT opaqueResizeChanged();
+    }
 }
 
 

--- a/src/ResizeHandle.h
+++ b/src/ResizeHandle.h
@@ -24,7 +24,8 @@ class ADS_EXPORT CResizeHandle : public QFrame
 {
 	Q_OBJECT
 	Q_DISABLE_COPY(CResizeHandle)
-    Q_PROPERTY(bool opaqueResize READ opaqueResize WRITE setOpaqueResize)
+    Q_PROPERTY(bool opaqueResize READ opaqueResize WRITE setOpaqueResize NOTIFY
+                   opaqueResizeChanged)
 private:
 	ResizeHandlePrivate* d; ///< private data (pimpl)
 	friend struct ResizeHandlePrivate;
@@ -96,6 +97,9 @@ public:
 	 * interactively moving the resize handle. Otherwise returns false.
 	 */
 	bool opaqueResize() const;
+
+Q_SIGNALS:
+    void opaqueResizeChanged();
 }; // class name
 } // namespace ads
 //-----------------------------------------------------------------------------

--- a/src/ads_globals.h
+++ b/src/ads_globals.h
@@ -152,14 +152,12 @@ enum eBitwiseOperator
  */
 enum SideBarLocation
 {
-	SideBarTop,
-	SideBarLeft,
-	SideBarRight,
-	SideBarBottom,
-	SideBarNone
+    SideBarTop,
+    SideBarLeft,
+    SideBarRight,
+    SideBarBottom,
+    SideBarNone
 };
-Q_ENUMS(SideBarLocation)
-
 
 namespace internal
 {

--- a/src/linux/FloatingWidgetTitleBar.cpp
+++ b/src/linux/FloatingWidgetTitleBar.cpp
@@ -28,8 +28,6 @@
 //============================================================================
 #include "FloatingWidgetTitleBar.h"
 
-#include <iostream>
-
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QToolButton>
@@ -104,18 +102,20 @@ void FloatingWidgetTitleBarPrivate::createLayout()
 	CloseButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 	CloseButton->setVisible(true);
 	CloseButton->setFocusPolicy(Qt::NoFocus);
-	_this->connect(CloseButton, SIGNAL(clicked()), SIGNAL(closeRequested()));
+    QObject::connect(CloseButton, &tCloseButton::clicked, _this,
+                     &CFloatingWidgetTitleBar::closeRequested);
 
-	_this->setMaximizedIcon(false);
-	MaximizeButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-	MaximizeButton->setVisible(true);
-	MaximizeButton->setFocusPolicy(Qt::NoFocus);
-	_this->connect(MaximizeButton, &QPushButton::clicked, _this, &CFloatingWidgetTitleBar::maximizeRequested);
+    _this->setMaximizedIcon(false);
+    MaximizeButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    MaximizeButton->setVisible(true);
+    MaximizeButton->setFocusPolicy(Qt::NoFocus);
+    QObject::connect(MaximizeButton, &QPushButton::clicked, _this,
+                     &CFloatingWidgetTitleBar::maximizeRequested);
 
-	QFontMetrics fm(TitleLabel->font());
-	int Spacing = qRound(fm.height() / 4.0);
+    QFontMetrics fm(TitleLabel->font());
+    int Spacing = qRound(fm.height() / 4.0);
 
-	// Fill the layout
+    // Fill the layout
 	QBoxLayout *Layout = new QBoxLayout(QBoxLayout::LeftToRight);
 	Layout->setContentsMargins(6, 0, 0, 0);
 	Layout->setSpacing(0);


### PR DESCRIPTION
Refering to #765 ,  I make some changes to fix the almost clazy warnings and also fix the crash when using muti-dockmanager. But only this warning I don't fix:

```bash
warning: Q_PROPERTY should have either NOTIFY or CONSTANT [clazy-qproperty-without-notify]
```

This seems a Q_PROPERTY for qml dev warning. I am not familar with qml so I leave it alone.

Feel free to ask me if there are bugs or problems.