### PR TITLE
Update DockManager.cpp

### DIFF
--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -530,7 +530,7 @@ CDockManager::CDockManager(QWidget *parent) :
 	window()->installEventFilter(this);
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    connect(qApp, &QApplication::focusWindowChanged, [this](QWindow* focusWindow)
+    connect(qApp, &QApplication::focusWindowChanged, this, [this](QWindow* focusWindow)
     {
         if (!focusWindow)
         {


### PR DESCRIPTION
Passing a context object as 3rd parameter when using QObject::connect
Based on https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/765