### PR TITLE
COMP: Fix warnings about override on public destructors

### DIFF
--- a/src/AutoHideTab.h
+++ b/src/AutoHideTab.h
@@ -93,7 +93,7 @@ public:
 	/**
 	 * Virtual Destructor
 	 */
-	virtual ~CAutoHideTab();
+    ~CAutoHideTab() override;
 
 	/**
 	 * Update stylesheet style if a property changes

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -199,7 +199,7 @@ public:
 	/**
 	 * Virtual Destructor
 	 */
-	virtual ~CDockAreaWidget();
+	~CDockAreaWidget() override;
 
 	/**
 	 * Returns the dock manager object this dock area belongs to

--- a/src/DockContainerWidget.h
+++ b/src/DockContainerWidget.h
@@ -219,7 +219,7 @@ public:
 	/**
 	 * Virtual Destructor
 	 */
-	virtual ~CDockContainerWidget();
+    ~CDockContainerWidget() override;
 
 	/**
 	 * Adds dockwidget into the given area.

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -289,7 +289,7 @@ public:
     /**
      * Virtual Destructor
      */
-    virtual ~CDockWidget();
+    ~CDockWidget() override;
 
     /**
      * We return a fixed minimum size hint or the size hint of the content

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -220,7 +220,7 @@ public:
 	/**
 	 * Virtual Destructor
 	 */
-	virtual ~CFloatingDockContainer();
+	~CFloatingDockContainer() override;
 
 	/**
 	 * Access function for the internal dock container


### PR DESCRIPTION
For our project we have turned some warnings into errors. Specifically we have introduced:

-Werror=inconsistent-missing-destructor-override # Winconsistent-missing-destructor-override: A overrides a destructor but is not marked "override"

We can certainly turn off the warnings/errors for QtADS but I thought these would help out.