### PR TITLE
fix docking drag drop problem on Linux wayland

### DIFF
--- a/src/DockOverlay.cpp
+++ b/src/DockOverlay.cpp
@@ -190,27 +190,32 @@ struct DockOverlayCrossPrivate
         }
 
 		l->setPixmap(createHighDpiDropIndicatorPixmap(size, DockWidgetArea, Mode));
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+        l->setWindowFlags(Qt::ToolTip);
+#else
 		l->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
-		l->setAttribute(Qt::WA_TranslucentBackground);
-		l->setProperty("dockWidgetArea", DockWidgetArea);
-		return l;
-	}
+#endif
+        l->setAttribute(Qt::WA_TranslucentBackground);
+        l->setProperty("dockWidgetArea", DockWidgetArea);
+        return l;
+    }
 
-	//============================================================================
-	void updateDropIndicatorIcon(QWidget* DropIndicatorWidget)
-	{
-		QLabel* l = qobject_cast<QLabel*>(DropIndicatorWidget);
+    //============================================================================
+    void updateDropIndicatorIcon(QWidget* DropIndicatorWidget)
+    {
+        QLabel* l = qobject_cast<QLabel*>(DropIndicatorWidget);
         const qreal metric = dropIndicatiorWidth(l);
 		const QSizeF size(metric, metric);
 
 		int Area = l->property("dockWidgetArea").toInt();
 		l->setPixmap(createHighDpiDropIndicatorPixmap(size, (DockWidgetArea)Area, Mode));
-	}
+    }
 
-	//============================================================================
-	QPixmap createHighDpiDropIndicatorPixmap(const QSizeF& size, DockWidgetArea DockWidgetArea,
-		CDockOverlay::eMode Mode)
-	{
+    //============================================================================
+    QPixmap createHighDpiDropIndicatorPixmap(const QSizeF& size,
+                                             DockWidgetArea DockWidgetArea,
+                                             CDockOverlay::eMode Mode)
+    {
 		QColor borderColor = iconColor(CDockOverlayCross::FrameColor);
 		QColor backgroundColor = iconColor(CDockOverlayCross::WindowBackgroundColor);
 		QColor overlayColor = iconColor(CDockOverlayCross::OverlayColor);
@@ -404,7 +409,7 @@ CDockOverlay::CDockOverlay(QWidget* parent, eMode Mode) :
 	d->Mode = Mode;
 	d->Cross = new CDockOverlayCross(this);
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
+    setWindowFlags(Qt::ToolTip | Qt::X11BypassWindowManagerHint);
 #else
 	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
 #endif
@@ -739,7 +744,8 @@ CDockOverlayCross::CDockOverlayCross(CDockOverlay* overlay) :
 {
 	d->DockOverlay = overlay;
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
+    setWindowFlags(Qt::ToolTip | Qt::WindowStaysOnTopHint
+                   | Qt::X11BypassWindowManagerHint);
 #else
 	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
 #endif

--- a/src/FloatingDragPreview.cpp
+++ b/src/FloatingDragPreview.cpp
@@ -290,9 +290,13 @@ CFloatingDragPreview::CFloatingDragPreview(QWidget* Content, QWidget* parent) :
 	}
 	else
 	{
-		setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
-		setAttribute(Qt::WA_NoSystemBackground);
-		setAttribute(Qt::WA_TranslucentBackground);
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+        setWindowFlags(Qt::ToolTip);
+#else
+        setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
+#endif
+        setAttribute(Qt::WA_NoSystemBackground);
+        setAttribute(Qt::WA_TranslucentBackground);
 	}
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)


### PR DESCRIPTION
Hello, I fix the drag drop problem on wayland. Here is the screenshot before applying this patch:

<img width="2271" height="1402" alt="屏幕截图_20251116_151707" src="https://github.com/user-attachments/assets/8da42de4-7e94-42a6-b8b7-db0054aecb07" />

Due to wayland limitation, frameless window can not reposition by programing. That's why will break up dragging and droping dock widget. I open debugging console on wayland and the screenshot as following:

<img width="2934" height="1399" alt="屏幕截图_20251116_155408" src="https://github.com/user-attachments/assets/41c3f519-a201-465a-8642-57b17b557739" />

As we can see from the image, we create many dialogs and set these frameless so `QWidget::move` not work on wayland.

While `Qt::Tool` equals `Qt::Popup | Qt::Dialog`, `Qt::ToolTip` is same as `Qt::Popup | Qt::Sheet`. `Qt::Sheet` is used for MacOS. I changed `Qt::Tool | Qt::FramelessWindowHint` to `Qt::ToolTip` and drag-and-drop works very well:

<img width="2283" height="1404" alt="屏幕截图_20251116_150750" src="https://github.com/user-attachments/assets/9c14f9de-9abf-4560-aeeb-bd8e9434a572" />

So, why? I dive into wayland protocol and found the reason.

When set `Qt::ToolTip` atrribute to a widget. Qt will create a `XdgPopupWindow` object:

<img width="2401" height="1095" alt="屏幕截图_20251116_160625" src="https://github.com/user-attachments/assets/0315ab0b-cd79-4054-b94b-b78d569ee9d7" />

According to protocol, `xdg_popup` have the ability to [reposition](https://wayland.app/protocols/xdg-shell#xdg_popup:request:reposition). So we can use the `Qt::ToolTip` atrribute to solve the problem.

However, floating window is still broken on wayland. It will crash the APP surface:

<img width="2097" height="1518" alt="image" src="https://github.com/user-attachments/assets/2c7783f1-3db9-4629-a164-b365bffbe09b" />

Also, it works well on Linux X11 (no change on Windows), tested with Qt6.10. This may a good solution for wayland native who don't need floating windows.

