### PR TITLE
Fix 2 crashes in singleShot timers while undocking tabs (especially in auto hide mode)

### DIFF
--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -37,6 +37,7 @@
 #include <QApplication>
 #include <QtGlobal>
 #include <QTimer>
+#include <QPointer>
 
 #include "FloatingDockContainer.h"
 #include "DockAreaWidget.h"
@@ -111,9 +112,15 @@ void DockAreaTabBarPrivate::updateTabs()
 			// Sometimes the synchronous calculation of the rectangular area fails
 			// Therefore we use QTimer::singleShot here to execute the call
 			// within the event loop - see #520
-			QTimer::singleShot(0, _this, [&, TabWidget]
+			QPointer<CDockAreaTabBar> __this = _this;
+			QPointer<CDockWidgetTab> __tabWidget = TabWidget;
+
+			QTimer::singleShot(0, TabWidget, [__this, __tabWidget]
 			{
-				_this->ensureWidgetVisible(TabWidget);
+				if (__this && __tabWidget)
+				{
+					__this->ensureWidgetVisible(__tabWidget);				
+				}
 			});
 		}
 		else

--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -151,7 +151,7 @@ public:
 	int VisibleDockAreaCount = -1;
 	CDockAreaWidget* TopLevelDockArea = nullptr;
 	QTimer DelayedAutoHideTimer;
-	CAutoHideTab* DelayedAutoHideTab;
+	QPointer<CAutoHideTab> DelayedAutoHideTab;
 	bool DelayedAutoHideShow = false;
 
 	/**
@@ -396,10 +396,12 @@ DockContainerWidgetPrivate::DockContainerWidgetPrivate(CDockContainerWidget* _pu
 	std::fill(std::begin(LastAddedAreaCache),std::end(LastAddedAreaCache), nullptr);
 	DelayedAutoHideTimer.setSingleShot(true);
 	DelayedAutoHideTimer.setInterval(500);
-	QObject::connect(&DelayedAutoHideTimer, &QTimer::timeout, [this](){
-		auto GlobalPos = DelayedAutoHideTab->mapToGlobal(QPoint(0, 0));
-		qApp->sendEvent(DelayedAutoHideTab, new QMouseEvent(QEvent::MouseButtonPress,
+	QObject::connect(&DelayedAutoHideTimer, &QTimer::timeout, [this](){		
+		if (DelayedAutoHideTab) {
+			auto GlobalPos = DelayedAutoHideTab->mapToGlobal(QPoint(0, 0));
+			qApp->sendEvent(DelayedAutoHideTab, new QMouseEvent(QEvent::MouseButtonPress,
 				QPoint(0, 0), GlobalPos, Qt::LeftButton, {Qt::LeftButton}, Qt::NoModifier));
+		}
 	});
 }
 


### PR DESCRIPTION
The first crash happens rarely while changing dock state programatically in startup phase. 
The second one can be checked with the demo application. Just add the following line in the constructor of the demo:

CDockManager::setAutoHideConfigFlag(ads::CDockManager::AutoHideShowOnMouseOver, true);

Then attach a dock to the side bar (hide mode), select it and drag it anywhwere -> it crashes.