### PR TITLE
Update title bar label when the widget's title changes.

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -929,6 +929,19 @@ void CDockAreaWidget::updateTitleBarVisibility()
 
 
 //============================================================================
+void CDockAreaWidget::updateWindowTitle()
+{
+	auto currentWidget = d->ContentsLayout->currentWidget();
+	if (d->TitleBar && currentWidget)
+	{
+		d->TitleBar->autoHideTitleLabel()->setText(currentWidget->windowTitle());
+	}
+
+	markTitleBarMenuOutdated();
+}
+
+
+//============================================================================
 void CDockAreaWidget::markTitleBarMenuOutdated()
 {
 	if (d->TitleBar)

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -166,6 +166,11 @@ protected:
 	void internalSetCurrentDockWidget(CDockWidget* DockWidget);
 
 	/**
+	 * Call this function to update the window title
+	 */
+	void updateWindowTitle();
+
+	/**
 	 * Marks tabs menu to update
 	 */
 	void markTitleBarMenuOutdated();

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -878,7 +878,7 @@ bool CDockWidget::event(QEvent *e)
 			}
 			if (d->DockArea)
 			{
-				d->DockArea->markTitleBarMenuOutdated();//update tabs menu
+				d->DockArea->updateWindowTitle();
 			}
 
 			auto FloatingWidget = floatingDockContainer();


### PR DESCRIPTION
When the title of the widget changed, it was updating the tabs, but was not updating the auto hide label which is used for the title bar when using tabs are at the bottom.