### PR TITLE
Fix label color in CDockWidgetTab in dark mode

### DIFF
--- a/src/stylesheets/default.css
+++ b/src/stylesheets/default.css
@@ -75,7 +75,7 @@ ads--CDockWidgetTab[activeTab="true"] {
 }
 
 ads--CDockWidgetTab QLabel {
-	color: palette(dark);
+	color: palette(text);
 }
 
 ads--CDockWidgetTab[activeTab="true"] QLabel {


### PR DESCRIPTION
We had an issue with the dark "Fusion" style (the dock widget tab titles' text was dark with a dark background).
It seems like this isn't a big deal on the light theme either, and definitely solves the dark theme issue.