### PR TITLE
Account for the tabs height when they are at the bottom.

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -1481,14 +1481,18 @@ QSize CDockAreaWidget::minimumSizeHint() const
 		return Super::minimumSizeHint();
 	}
 
+	int extraHeight = 0;
 	if (d->TitleBar->isVisible())
 	{
-		return d->MinSizeHint + QSize(0, d->TitleBar->minimumSizeHint().height());
+		extraHeight += d->TitleBar->minimumSizeHint().height();
 	}
-	else
+
+	if (CDockManager::testConfigFlag(CDockManager::TabsAtBottom) && d->tabBar()->isVisible())
 	{
-		return d->MinSizeHint;
+		extraHeight += d->tabBar()->minimumSizeHint().height();
 	}
+
+	return d->MinSizeHint + QSize(0, extraHeight);
 }
 
 


### PR DESCRIPTION
When the tabs are at the bottom, tabs were being clipped by the contents when the window size approached its minimum height.

To reproduce:
1. Start the AutoHideDragNDropExample example application
2. Dock the Properties at the bottom
3. Move Tab1 to be tabbed with the properties
4. Resize the tabbed container to its minimum height.

<img width="281" height="201" alt="ClippedTabs" src="https://github.com/user-attachments/assets/50e875ac-f901-400c-b657-e466637dca99" />