### PR TITLE
FloatingDockContainer uses windowIcon from parent widgets

### DIFF
--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -459,7 +459,7 @@ struct FloatingDockContainerPrivate
 		}
 		else
 		{
-			_this->setWindowIcon(QApplication::windowIcon());
+			_this->setWindowIcon(CurrentWidget->windowIcon());
 		}
 	}
 


### PR DESCRIPTION
The FloatingDockContainer now uses the windowIcon of the parent widgets, e.g. the widget the DockManager was created in. This falls back naturally to the QApplication windowIcon if no explicit icon was specified for any parent.

Since there could be multiple different windows inside the same application with different windowIcons, this is would be a better source of the tile bar icon of floating windows even if only one of these windows contains a DockManager, and is absolutely vital when using multiple DockManagers.