### PR TITLE
Toogle visibility of custom title bar based on fullscreen state

### DIFF
--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -850,6 +850,12 @@ void CFloatingDockContainer::changeEvent(QEvent *event)
 				this->showMaximized();
 			}
 		}
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+        if (d->TitleBar)
+        {
+            d->TitleBar->setVisible(!(isFloating() && isFullScreen()));
+        }
+#endif
 		break;
 
 	default:

--- a/src/linux/FloatingWidgetTitleBar.cpp
+++ b/src/linux/FloatingWidgetTitleBar.cpp
@@ -238,6 +238,20 @@ void CFloatingWidgetTitleBar::mouseDoubleClickEvent(QMouseEvent *event)
     }
 }
 
+//============================================================================
+QSize CFloatingWidgetTitleBar::sizeHint() const
+{
+    if (isVisible())
+    {
+        return QFrame::sizeHint();
+    }
+    else
+    {
+        // Allow titlebar to collapse when set invisible.
+        return QSize();
+    }
+}
+
 
 //============================================================================
 void CFloatingWidgetTitleBar::setMaximizedIcon(bool maximized)

--- a/src/linux/FloatingWidgetTitleBar.h
+++ b/src/linux/FloatingWidgetTitleBar.h
@@ -59,6 +59,7 @@ protected:
 	virtual void mouseReleaseEvent(QMouseEvent *ev) override;
 	virtual void mouseMoveEvent(QMouseEvent *ev) override;
     virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
+    virtual QSize sizeHint() const override;
 
     void setMaximizeIcon(const QIcon& Icon);
     QIcon maximizeIcon() const;


### PR DESCRIPTION
When using `CFloatingDockContainer` with a custom title bar, correctly respond to fullscreen window state by hiding the titlebar.

`QDockWidgetLayout::titleHeight()` is trying to reserve space even when the titlebar is technically already hidden, so override the  size-hint in that case.

This enables use of `CFloatingDockContainer::showFullScreen()` on floating docks in systems where the non-native title-bar is used.