### PR TITLE
Fixed Undock Button getting hidden after undocking and docking again …

### DIFF
--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -907,6 +907,7 @@ void DockContainerWidgetPrivate::addDockAreasToList(const QList<CDockAreaWidget*
 	{
 		DockArea->titleBarButton(TitleBarButtonClose)->setVisible(true);
 		DockArea->titleBarButton(TitleBarButtonAutoHide)->setVisible(true);
+		DockArea->titleBarButton(TitleBarButtonUndock)->setVisible(true);
 	}
 
 	// We need to ensure, that the dock area title bar is visible. The title bar


### PR DESCRIPTION
This fixes a bug where if the user drops a floating widget that contains only one single visible dock area, the Undock Button present in the title bar gets hidden and it never shows up again until the application is closed/reopened. 

There's a comment in the code mentioning the need to make it show up again. So it's probably just a small miss.

<img width="968" height="292" alt="image" src="https://github.com/user-attachments/assets/c61177e1-5ce9-4a29-a55e-54dd12eac313" />


This bug is not visible in the Demo application or on applications that have the Auto Hide Feature enabled. 
With that feature enabled, `updateTitleBarButtonVisibility` gets called. And this function "hides" the bug since it makes all buttons show up again:
<img width="563" height="262" alt="image" src="https://github.com/user-attachments/assets/7358a406-ba97-49d6-bd02-ac49f6d01e16" />
<img width="864" height="116" alt="image" src="https://github.com/user-attachments/assets/ed74bfe3-0d49-4f53-8c3f-83c82a7ed2b7" />
<img width="886" height="536" alt="image" src="https://github.com/user-attachments/assets/0833bc5a-5c45-4504-aded-52823540936c" />

