### PR TITLE
Fix visibility with QWebEngineView

### DIFF
--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -374,6 +374,7 @@ struct FloatingDockContainerPrivate
 	QPoint DragStartPos;
 	bool Hiding = false;
 	bool AutoHideChildren = true;
+	bool HideContentOnNextHide = false;
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     QWidget* MouseEventHandler = nullptr;
     CFloatingWidgetTitleBar* TitleBar = nullptr;
@@ -959,6 +960,15 @@ void CFloatingDockContainer::closeEvent(QCloseEvent *event)
 		return;
 	}
 
+	// New bug (QWebEngineView reload side effect):
+	// when a WebEngine-based dock is tabified into a floating container, the
+	// embedded native/web process can trigger delayed hide/show cycles on the
+	// floating window. If every non-spontaneous hide propagates to
+	// DockWidget->toggleView(false), unrelated tabs are marked closed and seem
+	// to "disappear". We therefore arm HideContentOnNextHide only for the 
+	// explicit close path.
+	d->HideContentOnNextHide = true;
+
 	// In Qt version after 5.9.2 there seems to be a bug that causes the
 	// QWidget::event() function to not receive any NonClientArea mouse
 	// events anymore after a close/show cycle. The bug is reported here:
@@ -985,6 +995,15 @@ void CFloatingDockContainer::hideEvent(QHideEvent *event)
     {
         return;
     }
+
+	// Only a close operation should propagate hide->toggleView(false) to
+	// child dock widgets. Generic hide/show cycles (e.g. from platform or
+	// embedded native content) must not change dock open/closed state.
+	if (!d->HideContentOnNextHide)
+	{
+		return;
+	}
+	d->HideContentOnNextHide = false;
 
 	if ( d->AutoHideChildren )
 	{


### PR DESCRIPTION
Toggling visibility of floating docked windows protected against external hide/show cycle by QWebEngineView.