### PR TITLE
Unbind containers from DockManager to prevent accidental reuse

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -609,8 +609,7 @@ void CDockAreaWidget::removeDockWidget(CDockWidget* DockWidget)
 		{
 			if(CFloatingDockContainer*  FloatingDockContainer = DockContainer->floatingWidget())
 			{
-				FloatingDockContainer->hide();
-				FloatingDockContainer->deleteLater();
+				FloatingDockContainer->finishDropOperation();
 			}
 		}
 	}

--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -2218,6 +2218,17 @@ CDockManager* CDockContainerWidget::dockManager() const
 
 
 //===========================================================================
+void CDockContainerWidget::removeFromDockManager()
+{
+	if (d->DockManager)
+	{
+		d->DockManager->removeDockContainer(this);
+		d->DockManager.clear();
+	}
+}
+
+
+//===========================================================================
 void CDockContainerWidget::handleAutoHideWidgetEvent(QEvent* e, QWidget* w)
 {
 	if (!CDockManager::testAutoHideConfigFlag(CDockManager::AutoHideShowOnMouseOver))

--- a/src/DockContainerWidget.h
+++ b/src/DockContainerWidget.h
@@ -86,6 +86,9 @@ private:
 	friend AutoHideDockContainerPrivate;
 	friend CAutoHideSideBar;
 
+private Q_SLOTS:
+	void removeFromDockManager();
+
 protected:
 	/**
 	 * Handles activation events to update zOrderIndex

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -768,7 +768,8 @@ void CDockManager::registerFloatingWidget(CFloatingDockContainer* FloatingWidget
 //============================================================================
 void CDockManager::removeFloatingWidget(CFloatingDockContainer* FloatingWidget)
 {
-	d->FloatingWidgets.removeAll(FloatingWidget);
+	int removed = d->FloatingWidgets.removeAll(FloatingWidget);
+	Q_ASSERT(removed == 1);
 }
 
 //============================================================================
@@ -783,7 +784,8 @@ void CDockManager::removeDockContainer(CDockContainerWidget* DockContainer)
 {
 	if (this != DockContainer)
 	{
-		d->Containers.removeAll(DockContainer);
+		int removed = d->Containers.removeAll(DockContainer);
+		Q_ASSERT(removed == 1);
 	}
 }
 

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -500,6 +500,9 @@ void FloatingDockContainerPrivate::titleMouseReleaseEvent()
 		return;
 	}
 
+	// DockManager will be unlinked from this within DropContainer->dropFloatingWidget
+	const auto OriginalDockManager = this->DockManager.data();
+
 	if (DockManager->dockAreaOverlay()->dropAreaUnderCursor() != InvalidDockWidgetArea
 	 || DockManager->containerOverlay()->dropAreaUnderCursor() != InvalidDockWidgetArea)
 	{
@@ -533,8 +536,8 @@ void FloatingDockContainerPrivate::titleMouseReleaseEvent()
 		DropContainer->dropFloatingWidget(_this, QCursor::pos());
 	}
 
-	DockManager->containerOverlay()->hideOverlay();
-	DockManager->dockAreaOverlay()->hideOverlay();
+	OriginalDockManager->containerOverlay()->hideOverlay();
+	OriginalDockManager->dockAreaOverlay()->hideOverlay();
 }
 
 
@@ -1220,8 +1223,9 @@ void CFloatingDockContainer::finishDropOperation()
 	if (d->DockManager)
 	{
 		d->DockManager->removeFloatingWidget(this);
-		d->DockManager->removeDockContainer(this->dockContainer());
+		d->DockManager.clear();
 	}
+	this->dockContainer()->removeFromDockManager();
 }
 
 //============================================================================


### PR DESCRIPTION
When explicitly removing container widget externally (eventually ending up in `CDockAreaWidget::removeDockWidget`), there's a short time frame in which the old container was not removed from the `CDockManager` yet, but already marked as `deleteLater`.

This results in possible reuse of the already-to-be-deleted-container by `CDockManager` when immediately adding new container widgets before the `deleteLater` has come into effect.

In order to fix this:
- Eager de-registration from `CDockManager` in  `CDockAreaWidget::removeDockWidget`
- Explicitly break up the link from already orphaned `CFloatingDockContainer`  and `CDockContainerWidget` back to `CDockManager` to avoid further side effects.