### PR TITLE
Make possible to add DockWidget without activating them

### DIFF
--- a/src/DockAreaWidget.cpp
+++ b/src/DockAreaWidget.cpp
@@ -524,9 +524,9 @@ void CDockAreaWidget::setAutoHideDockContainer(CAutoHideDockContainer* AutoHideD
 
 
 //============================================================================
-void CDockAreaWidget::addDockWidget(CDockWidget* DockWidget)
+void CDockAreaWidget::addDockWidget(CDockWidget* DockWidget, bool activate)
 {
-	insertDockWidget(d->ContentsLayout->count(), DockWidget);
+	insertDockWidget(d->ContentsLayout->count(), DockWidget, activate);
 }
 
 

--- a/src/DockAreaWidget.h
+++ b/src/DockAreaWidget.h
@@ -122,7 +122,7 @@ protected:
 	 * Add a new dock widget to dock area.
 	 * All dockwidgets in the dock area tabified in a stacked layout with tabs
 	 */
-	void addDockWidget(CDockWidget* DockWidget);
+	void addDockWidget(CDockWidget* DockWidget, bool activate = true);
 
 	/**
 	 * Removes the given dock widget from the dock area

--- a/src/DockContainerWidget.cpp
+++ b/src/DockContainerWidget.cpp
@@ -163,13 +163,13 @@ public:
 	 * Adds dock widget to container and returns the dock area that contains
 	 * the inserted dock widget
 	 */
-	CDockAreaWidget* addDockWidgetToContainer(DockWidgetArea area, CDockWidget* Dockwidget);
+	CDockAreaWidget* addDockWidgetToContainer(DockWidgetArea area, CDockWidget* Dockwidget, bool activate = true);
 
 	/**
 	 * Adds dock widget to a existing DockWidgetArea
 	 */
 	CDockAreaWidget* addDockWidgetToDockArea(DockWidgetArea area, CDockWidget* Dockwidget,
-		CDockAreaWidget* TargetDockArea, int Index = -1);
+		CDockAreaWidget* TargetDockArea, int Index = -1, bool activate = true);
 
 	/**
 	 * Add dock area to this container
@@ -1234,10 +1234,10 @@ bool DockContainerWidgetPrivate::restoreChildNodes(CDockingStateReader& s,
 
 //============================================================================
 CDockAreaWidget* DockContainerWidgetPrivate::addDockWidgetToContainer(DockWidgetArea area,
-	CDockWidget* Dockwidget)
+	CDockWidget* Dockwidget, bool activate)
 {
 	CDockAreaWidget* NewDockArea = new CDockAreaWidget(DockManager, _this);
-	NewDockArea->addDockWidget(Dockwidget);
+	NewDockArea->addDockWidget(Dockwidget, activate);
 	addDockArea(NewDockArea, area);
 	NewDockArea->updateTitleBarVisibility();
 	LastAddedAreaCache[areaIdToIndex(area)] = NewDockArea;
@@ -1350,17 +1350,17 @@ void DockContainerWidgetPrivate::dumpRecursive(int level, QWidget* widget)
 
 //============================================================================
 CDockAreaWidget* DockContainerWidgetPrivate::addDockWidgetToDockArea(DockWidgetArea area,
-	CDockWidget* Dockwidget, CDockAreaWidget* TargetDockArea, int Index)
+	CDockWidget* Dockwidget, CDockAreaWidget* TargetDockArea, int Index, bool activate)
 {
 	if (CenterDockWidgetArea == area)
 	{
-		TargetDockArea->insertDockWidget(Index, Dockwidget);
+		TargetDockArea->insertDockWidget(Index, Dockwidget, activate);
 		TargetDockArea->updateTitleBarVisibility();
 		return TargetDockArea;
 	}
 
 	CDockAreaWidget* NewDockArea = new CDockAreaWidget(DockManager, _this);
-	NewDockArea->addDockWidget(Dockwidget);
+	NewDockArea->addDockWidget(Dockwidget, activate);
 	auto InsertParam = internal::dockAreaInsertParameters(area);
 
 	auto TargetAreaSplitter = TargetDockArea->parentSplitter();
@@ -1442,7 +1442,7 @@ CDockContainerWidget::~CDockContainerWidget()
 
 //============================================================================
 CDockAreaWidget* CDockContainerWidget::addDockWidget(DockWidgetArea area, CDockWidget* Dockwidget,
-	CDockAreaWidget* DockAreaWidget, int Index)
+	CDockAreaWidget* DockAreaWidget, int Index, bool activate)
 {
 	auto TopLevelDockWidget = topLevelDockWidget();
 	CDockAreaWidget* OldDockArea = Dockwidget->dockAreaWidget();
@@ -1455,11 +1455,11 @@ CDockAreaWidget* CDockContainerWidget::addDockWidget(DockWidgetArea area, CDockW
 	CDockAreaWidget* DockArea;
 	if (DockAreaWidget)
 	{
-		DockArea = d->addDockWidgetToDockArea(area, Dockwidget, DockAreaWidget, Index);
+		DockArea = d->addDockWidgetToDockArea(area, Dockwidget, DockAreaWidget, Index, activate);
 	}
 	else
 	{
-		DockArea = d->addDockWidgetToContainer(area, Dockwidget);
+		DockArea = d->addDockWidgetToContainer(area, Dockwidget, activate);
 	}
 
 	if (TopLevelDockWidget)

--- a/src/DockContainerWidget.h
+++ b/src/DockContainerWidget.h
@@ -229,7 +229,7 @@ public:
 	 * \return Returns the dock area widget that contains the new DockWidget
 	 */
 	CDockAreaWidget* addDockWidget(DockWidgetArea area, CDockWidget* Dockwidget,
-		CDockAreaWidget* DockAreaWidget = nullptr, int Index = -1);
+		CDockAreaWidget* DockAreaWidget = nullptr, int Index = -1, bool activate = true);
 
 	/**
 	 * Removes dockwidget

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -981,11 +981,11 @@ void CDockManager::restoreHiddenFloatingWidgets()
 
 //============================================================================
 CDockAreaWidget* CDockManager::addDockWidget(DockWidgetArea area,
-	CDockWidget* Dockwidget, CDockAreaWidget* DockAreaWidget, int Index)
+	CDockWidget* Dockwidget, CDockAreaWidget* DockAreaWidget, int Index, bool activate)
 {
 	d->DockWidgetsMap.insert(Dockwidget->objectName(), Dockwidget);
 	auto Container = DockAreaWidget ? DockAreaWidget->dockContainer() : this;
-	auto AreaOfAddedDockWidget = Container->addDockWidget(area, Dockwidget, DockAreaWidget, Index);
+	auto AreaOfAddedDockWidget = Container->addDockWidget(area, Dockwidget, DockAreaWidget, Index, activate);
 	Q_EMIT dockWidgetAdded(Dockwidget);
 	return AreaOfAddedDockWidget;
 }
@@ -1021,25 +1021,25 @@ CAutoHideDockContainer* CDockManager::addAutoHideDockWidgetToContainer(SideBarLo
 
 //============================================================================
 CDockAreaWidget* CDockManager::addDockWidgetTab(DockWidgetArea area,
-	CDockWidget* Dockwidget)
+	CDockWidget* Dockwidget, bool activate)
 {
 	CDockAreaWidget* AreaWidget = lastAddedDockAreaWidget(area);
 	if (AreaWidget)
 	{
-		return addDockWidget(ads::CenterDockWidgetArea, Dockwidget, AreaWidget);
+		return addDockWidget(ads::CenterDockWidgetArea, Dockwidget, AreaWidget, activate);
 	}
 	else
 	{
-		return addDockWidget(area, Dockwidget, nullptr);
+		return addDockWidget(area, Dockwidget, nullptr, -1, activate);
 	}
 }
 
 
 //============================================================================
 CDockAreaWidget* CDockManager::addDockWidgetTabToArea(CDockWidget* Dockwidget,
-	CDockAreaWidget* DockAreaWidget, int Index)
+	CDockAreaWidget* DockAreaWidget, int Index, bool activate)
 {
-	return addDockWidget(ads::CenterDockWidgetArea, Dockwidget, DockAreaWidget, Index);
+	return addDockWidget(ads::CenterDockWidgetArea, Dockwidget, DockAreaWidget, Index, activate);
 }
 
 

--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -405,7 +405,7 @@ public:
 	 * \return Returns the dock area widget that contains the new DockWidget
 	 */
 	CDockAreaWidget* addDockWidget(DockWidgetArea area, CDockWidget* Dockwidget,
-		CDockAreaWidget* DockAreaWidget = nullptr, int Index = -1);
+		CDockAreaWidget* DockAreaWidget = nullptr, int Index = -1, bool activate = true);
 
 	/**
 	 * Adds dockwidget into the given container.
@@ -438,7 +438,7 @@ public:
 	 * dock area widget is created.
 	 */
 	CDockAreaWidget* addDockWidgetTab(DockWidgetArea area,
-		CDockWidget* Dockwidget);
+		CDockWidget* Dockwidget, bool activate = true);
 
 	/**
 	 * This function will add the given Dockwidget to the given DockAreaWidget
@@ -447,7 +447,7 @@ public:
 	 * inserted at the specified position.
 	 */
 	CDockAreaWidget* addDockWidgetTabToArea(CDockWidget* Dockwidget,
-		CDockAreaWidget* DockAreaWidget, int Index = -1);
+		CDockAreaWidget* DockAreaWidget, int Index = -1, bool activate = true);
 
 	/**
 	 * Adds the given DockWidget floating and returns the created


### PR DESCRIPTION
Hello,

This PR is a proposal for a feature that is useful to me.
The modifications propagate the activate parameter from `CDockAreaWidget::insertDockWidget` in order to be able to create `DockWidget` without activating them. The behavior by default remains the same as before with the default value.
It's quite useful when building a view with multiple `DockWidget` that don't mean to have the focus at the beginning.

Hope you will accept the changes.

Regards,