### PR TITLE
feat: merge into existing dock area when unpinning from auto-hide

### DIFF
--- a/src/AutoHideDockContainer.cpp
+++ b/src/AutoHideDockContainer.cpp
@@ -415,7 +415,31 @@ void CAutoHideDockContainer::moveContentsToParent()
 	// to the user and he does not have to search where the widget was inserted.
 	d->DockWidget->setDockArea(nullptr);
 	auto DockContainer = dockContainer();
-	DockContainer->addDockWidget(d->getDockWidgetArea(d->SideTabBarArea), d->DockWidget);
+	auto targetArea = d->getDockWidgetArea(d->SideTabBarArea);
+
+	// Try to merge into an existing opened dock area at the same location
+	// instead of creating a new split. This provides a cleaner layout when
+	// multiple widgets are unpinned from the same sidebar location.
+	CDockAreaWidget* existingArea = nullptr;
+	for (auto area : DockContainer->openedDockAreas())
+	{
+		if (!area || area->isAutoHide()) continue;
+		auto areaLocation = d->getDockWidgetArea(area->calculateSideTabBarArea());
+		if (areaLocation == targetArea)
+		{
+			existingArea = area;
+			break;
+		}
+	}
+
+	if (existingArea)
+	{
+		DockContainer->addDockWidget(CenterDockWidgetArea, d->DockWidget, existingArea);
+	}
+	else
+	{
+		DockContainer->addDockWidget(targetArea, d->DockWidget);
+	}
 }
 
 


### PR DESCRIPTION
## Problem

When a dock widget is unpinned (moved from auto-hide sidebar back to the main layout), `moveContentsToParent()` always calls `addDockWidget(targetArea, widget)` which creates a new split area. This leads to fragmented layouts when multiple widgets are unpinned from the same sidebar location.

For example, if "Projects" and "Navigator" are both pinned to the left sidebar and then unpinned one after another, they end up in separate split areas instead of being tabbed together.

## Solution

Before creating a new area, search for an existing opened dock area at the same target location using `calculateSideTabBarArea()`. If a matching area is found, the widget is merged as a tab via `addDockWidget(CenterDockWidgetArea, widget, existingArea)`. If no match exists, the original behavior is preserved.

## Changes

- `AutoHideDockContainer.cpp`: Modified `moveContentsToParent()` to search for existing areas at the same location and merge as tab

## Testing

- Pinned 3 widgets to left sidebar → unpinned all → they merge as tabs in one area instead of creating 3 splits
- Unpinning from different sidebar locations (left, right, bottom) still creates separate areas correctly
- Single widget unpin with no existing area works as before (fallback path)