### PR TITLE
Make all tab text readable in dark mode (753)

### DIFF
--- a/src/stylesheets/default_linux.css
+++ b/src/stylesheets/default_linux.css
@@ -85,7 +85,7 @@ ads--CDockWidgetTab[activeTab="true"] {
 
 
 ads--CDockWidgetTab QLabel {
-	color: palette(dark);
+	color: palette(text);
 }
 
 

--- a/src/stylesheets/focus_highlighting.css
+++ b/src/stylesheets/focus_highlighting.css
@@ -88,7 +88,7 @@ ads--CDockWidgetTab[activeTab="true"] {
 }
 
 ads--CDockWidgetTab QLabel {
-	color: palette(dark);
+	color: palette(text);
 }
 
 ads--CDockWidgetTab[activeTab="true"] QLabel {
@@ -138,7 +138,7 @@ ads--CDockWidgetTab[focused="true"] > #tabCloseButton:pressed {
 }
 
 ads--CDockWidgetTab[focused="true"] QLabel {
-	color: palette(light);
+	color: palette(highlighted-text);
 }
 
 

--- a/src/stylesheets/focus_highlighting_linux.css
+++ b/src/stylesheets/focus_highlighting_linux.css
@@ -101,7 +101,7 @@ ads--CDockWidgetTab[activeTab="true"] {
 }
 
 ads--CDockWidgetTab QLabel {
-        color: palette(dark);
+        color: palette(text);
 }
 
 ads--CDockWidgetTab[activeTab="true"] QLabel {
@@ -148,7 +148,7 @@ ads--CDockWidgetTab[focused="true"] > #tabCloseButton:pressed {
 }
 
 ads--CDockWidgetTab[focused="true"] QLabel {
-        color: palette(light);
+        color: palette(highlighted-text);
 }
 
 


### PR DESCRIPTION
A previous patch fixed this on non-focus highlighted platforms

Use `highlighted-text` to ensure brighter colour on focus-highlighted tabs