### PR TITLE
feat: add preferred auto-hide sidebar location per dock widget

### DIFF
--- a/src/AutoHideDockContainer.cpp
+++ b/src/AutoHideDockContainer.cpp
@@ -415,7 +415,31 @@ void CAutoHideDockContainer::moveContentsToParent()
 	// to the user and he does not have to search where the widget was inserted.
 	d->DockWidget->setDockArea(nullptr);
 	auto DockContainer = dockContainer();
-	DockContainer->addDockWidget(d->getDockWidgetArea(d->SideTabBarArea), d->DockWidget);
+	auto targetArea = d->getDockWidgetArea(d->SideTabBarArea);
+
+	// If the widget has a preferred auto-hide location, try to find an existing
+	// opened dock area that contains a widget with the same preferred location
+	// and merge as a tab instead of creating a new split.
+	auto preferred = d->DockWidget->preferredAutoHideSideBarLocation();
+	if (preferred != SideBarNone)
+	{
+		for (auto area : DockContainer->openedDockAreas())
+		{
+			if (!area || area->isAutoHide()) continue;
+			// Check if any widget in this area has the same preferred location
+			for (auto dw : area->dockWidgets())
+			{
+				if (dw && dw->preferredAutoHideSideBarLocation() == preferred)
+				{
+					DockContainer->addDockWidget(CenterDockWidgetArea,
+						d->DockWidget, area);
+					return;
+				}
+			}
+		}
+	}
+
+	DockContainer->addDockWidget(targetArea, d->DockWidget);
 }
 
 

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -96,7 +96,8 @@ struct DockWidgetPrivate
 	WidgetFactory* Factory = nullptr;
 	QPointer<CAutoHideTab> SideTabWidget;
 	CDockWidget::eToolBarStyleSource ToolBarStyleSource = CDockWidget::ToolBarStyleFromDockManager;
-	
+	SideBarLocation PreferredAutoHideSideBarLocation = SideBarNone;
+
 	/**
 	 * Private data constructor
 	 */
@@ -651,6 +652,20 @@ bool CDockWidget::isAutoHide() const
 SideBarLocation CDockWidget::autoHideLocation() const
 {
 	return isAutoHide() ? autoHideDockContainer()->sideBarLocation() : SideBarNone;
+}
+
+
+//============================================================================
+void CDockWidget::setPreferredAutoHideSideBarLocation(SideBarLocation Location)
+{
+	d->PreferredAutoHideSideBarLocation = Location;
+}
+
+
+//============================================================================
+SideBarLocation CDockWidget::preferredAutoHideSideBarLocation() const
+{
+	return d->PreferredAutoHideSideBarLocation;
 }
 
 
@@ -1337,7 +1352,15 @@ void CDockWidget::setAutoHide(bool Enable, SideBarLocation Location, int TabInde
 	}
 	else
 	{
-		auto area = (SideBarNone == Location) ? DockArea->calculateSideTabBarArea() : Location;
+		auto area = Location;
+		if (SideBarNone == area && d->PreferredAutoHideSideBarLocation != SideBarNone)
+		{
+			area = d->PreferredAutoHideSideBarLocation;
+		}
+		else if (SideBarNone == area)
+		{
+			area = DockArea->calculateSideTabBarArea();
+		}
 		dockContainer()->createAndSetupAutoHideContainer(area, this, TabIndex);
 	}
 }

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -423,6 +423,22 @@ public:
     SideBarLocation autoHideLocation() const;
 
     /**
+     * Sets the preferred auto-hide sidebar location for this dock widget.
+     * When set to a value other than SideBarNone, the pin button will place
+     * this widget in the specified sidebar instead of using geometry-based
+     * detection. When unpinning, widgets with the same preferred location
+     * will be merged as tabs in the same dock area.
+     * Set to SideBarNone (default) to use the original geometry-based behavior.
+     */
+    void setPreferredAutoHideSideBarLocation(SideBarLocation Location);
+
+    /**
+     * Returns the preferred auto-hide sidebar location, or SideBarNone
+     * if no preference is set (geometry-based detection will be used).
+     */
+    SideBarLocation preferredAutoHideSideBarLocation() const;
+
+    /**
      * This property holds whether the dock widget is floating.
      * A dock widget is only floating, if it is the one and only widget inside
      * of a floating container. If there are more than one dock widget in a


### PR DESCRIPTION
## Problem

When a dock widget is pinned to the auto-hide sidebar, the sidebar location is determined by `calculateSideTabBarArea()` which uses geometry-based detection (measuring distances to container borders). This works for simple layouts, but in complex applications with fixed panel arrangements (e.g., EDA tools with Project/Navigator on left, Properties on right, Output on bottom), the geometry detection can place widgets in unexpected sidebar locations — especially after the layout has been rearranged by the user.

Additionally, when multiple widgets are unpinned from the same sidebar, each one creates a new split area instead of merging as tabs. This fragments the layout unnecessarily.

## Solution

Add a `preferredAutoHideSideBarLocation` property to `CDockWidget` that allows applications to specify where a widget should be pinned, overriding geometry-based detection.

**New API:**
```cpp
void CDockWidget::setPreferredAutoHideSideBarLocation(SideBarLocation Location);
SideBarLocation CDockWidget::preferredAutoHideSideBarLocation() const;
```

**Behavior:**
- **Pin (auto-hide):** If `preferredAutoHideSideBarLocation` is set (not `SideBarNone`), use it instead of `calculateSideTabBarArea()`. If `SideBarNone` (default), fall back to existing geometry-based detection.
- **Unpin (restore):** When unpinning, search for an existing opened dock area containing a widget with the same preferred location. If found, merge as a tab instead of creating a new split. If not found, use the default behavior.

**Backward compatible:** Default value is `SideBarNone`, preserving existing behavior for all applications that don't use this feature.

## Changes

- `DockWidget.h`: Add `setPreferredAutoHideSideBarLocation()` / `preferredAutoHideSideBarLocation()` declarations
- `DockWidget.cpp`: Add `PreferredAutoHideSideBarLocation` member + getter/setter + use preferred location in `setAutoHide()`
- `AutoHideDockContainer.cpp`: In `moveContentsToParent()`, search for existing area with same preferred location and merge as tab

## Usage Example

```cpp
// Application setup: define preferred sidebar locations
projectsDock->setPreferredAutoHideSideBarLocation(SideBarLeft);
navigatorDock->setPreferredAutoHideSideBarLocation(SideBarLeft);
propertiesDock->setPreferredAutoHideSideBarLocation(SideBarRight);
outputDock->setPreferredAutoHideSideBarLocation(SideBarBottom);

// Now pinning always goes to the specified sidebar,
// and unpinning merges widgets with the same preferred location as tabs
```