### PR TITLE
BUG: Fixes "overrides a destructor but is not marked 'override'"

### DIFF
--- a/src/DockAreaTitleBar.h
+++ b/src/DockAreaTitleBar.h
@@ -176,7 +176,7 @@ public:
 	/**
 	 * Virtual Destructor
 	 */
-	virtual ~CDockAreaTitleBar();
+	~CDockAreaTitleBar() override;
 
 	/**
 	 * Returns the pointer to the tabBar()

--- a/src/DockWidgetTab.h
+++ b/src/DockWidgetTab.h
@@ -91,7 +91,7 @@ public:
 	/**
 	 * Virtual Destructor
 	 */
-	virtual ~CDockWidgetTab();
+	~CDockWidgetTab() override;
 
 	/**
 	 * Returns true, if this is the active tab


### PR DESCRIPTION
fixes compiler error if compiling with flag [-Werror,-Winconsistent-missing-destructor-override] 