### PR TITLE
Wayland: render drag preview and overlays as child widgets instead of top-level Qt::Tool

### DIFF
--- a/src/DockOverlay.cpp
+++ b/src/DockOverlay.cpp
@@ -397,21 +397,20 @@ int DockOverlayPrivate::sideBarMouseZone(SideBarLocation sideBarLocation)
 
 
 //============================================================================
+// Wayland: parent the overlay to the manager's top-level window and drop
+// the Qt::Tool flags. Top-level placement in screen coordinates is unreliable
+// under Wayland, which left the indicators stuck over the wrong dock area.
 CDockOverlay::CDockOverlay(QWidget* parent, eMode Mode) :
-	QFrame(parent),
+	QFrame(parent ? parent->window() : nullptr),
 	d(new DockOverlayPrivate(this))
 {
 	d->Mode = Mode;
 	d->Cross = new CDockOverlayCross(this);
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
-#else
-	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
-#endif
 	setWindowOpacity(1);
 	setWindowTitle("DockOverlay");
 	setAttribute(Qt::WA_NoSystemBackground);
 	setAttribute(Qt::WA_TranslucentBackground);
+	setAttribute(Qt::WA_TransparentForMouseEvents);
 
 	d->Cross->setVisible(false);
 	setVisible(false);
@@ -570,9 +569,10 @@ DockWidgetArea CDockOverlay::showOverlay(QWidget* target)
 	// Move it over the target.
 	hide();
 	resize(target->size());
-	QPoint TopLeft = target->mapToGlobal(target->rect().topLeft());
-	move(TopLeft);
+	const QPoint TopLeftGlobal = target->mapToGlobal(target->rect().topLeft());
+	move(parentWidget() ? parentWidget()->mapFromGlobal(TopLeftGlobal) : TopLeftGlobal);
 	show();
+	raise();
 	d->Cross->updatePosition();
 	d->Cross->updateOverlayIcons();
 	return dropAreaUnderCursor();
@@ -733,18 +733,15 @@ QPoint DockOverlayCrossPrivate::areaGridPosition(const DockWidgetArea area)
 
 
 //============================================================================
+// Wayland: see CDockOverlay above for the rationale.
 CDockOverlayCross::CDockOverlayCross(CDockOverlay* overlay) :
-	QWidget(overlay->parentWidget()),
+	QWidget(overlay->parentWidget() ? overlay->parentWidget()->window() : nullptr),
 	d(new DockOverlayCrossPrivate(this))
 {
 	d->DockOverlay = overlay;
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
-#else
-	setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
-#endif
 	setWindowTitle("DockOverlayCross");
 	setAttribute(Qt::WA_TranslucentBackground);
+	setAttribute(Qt::WA_TransparentForMouseEvents);
 
 	d->GridLayout = new QGridLayout();
 	d->GridLayout->setSpacing(0);
@@ -784,7 +781,10 @@ void CDockOverlayCross::setupOverlayCross(CDockOverlay::eMode Mode)
 //============================================================================
 void CDockOverlayCross::updateOverlayIcons()
 {
-	if (windowHandle()->devicePixelRatio() == d->LastDevicePixelRatio)
+	// Wayland: devicePixelRatioF() walks the parent chain; the original
+	// windowHandle()->devicePixelRatio() segfaults for a child widget.
+	const qreal CurrentRatio = devicePixelRatioF();
+	if (CurrentRatio == d->LastDevicePixelRatio)
 	{
 		return;
 	}
@@ -793,11 +793,7 @@ void CDockOverlayCross::updateOverlayIcons()
 	{
 		d->updateDropIndicatorIcon(Widget);
 	}
-#if QT_VERSION >= 0x050600
-	d->LastDevicePixelRatio = devicePixelRatioF();
-#else
-    d->LastDevicePixelRatio = devicePixelRatio();
-#endif
+	d->LastDevicePixelRatio = CurrentRatio;
 }
 
 
@@ -911,11 +907,10 @@ void CDockOverlayCross::showEvent(QShowEvent*)
 void CDockOverlayCross::updatePosition()
 {
 	resize(d->DockOverlay->size());
-	QPoint TopLeft = d->DockOverlay->pos();
-	QPoint Offest((this->width() - d->DockOverlay->width()) / 2,
+	const QPoint Offset((this->width() - d->DockOverlay->width()) / 2,
 		(this->height() - d->DockOverlay->height()) / 2);
-	QPoint CrossTopLeft = TopLeft - Offest;
-	move(CrossTopLeft);
+	move(d->DockOverlay->pos() - Offset);
+	raise();
 }
 
 

--- a/src/DockOverlay.cpp
+++ b/src/DockOverlay.cpp
@@ -406,7 +406,6 @@ CDockOverlay::CDockOverlay(QWidget* parent, eMode Mode) :
 {
 	d->Mode = Mode;
 	d->Cross = new CDockOverlayCross(this);
-	setWindowOpacity(1);
 	setWindowTitle("DockOverlay");
 	setAttribute(Qt::WA_NoSystemBackground);
 	setAttribute(Qt::WA_TranslucentBackground);

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -1233,7 +1233,6 @@ void CFloatingDockContainer::finishDragging()
 {
 	ADS_PRINT("CFloatingDockContainer::finishDragging");
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-	setWindowOpacity(1);
 	activateWindow();
 	if (d->MouseEventHandler)
 	{

--- a/src/FloatingDragPreview.cpp
+++ b/src/FloatingDragPreview.cpp
@@ -276,8 +276,14 @@ void FloatingDragPreviewPrivate::createFloatingWidget()
 
 
 //============================================================================
+// Wayland: in the frameless config, parent the preview to the manager's
+// top-level window so it renders as a translucent child instead of a Qt::Tool
+// top-level. Wayland refuses to honour client-driven move() of top-levels in
+// screen coordinates; child widgets work on every backend.
 CFloatingDragPreview::CFloatingDragPreview(QWidget* Content, QWidget* parent) :
-	QWidget(parent),
+	QWidget((parent && !CDockManager::testConfigFlag(CDockManager::DragPreviewHasWindowFrame))
+	            ? parent->window()
+	            : parent),
 	d(new FloatingDragPreviewPrivate(this))
 {
 	d->Content = Content;
@@ -287,19 +293,20 @@ CFloatingDragPreview::CFloatingDragPreview(QWidget* Content, QWidget* parent) :
 	{
 		setWindowFlags(
 			Qt::Window | Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint);
+
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+		auto Flags = windowFlags();
+		Flags |= Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint;
+		setWindowFlags(Flags);
+#endif
 	}
 	else
 	{
-		setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
 		setAttribute(Qt::WA_NoSystemBackground);
 		setAttribute(Qt::WA_TranslucentBackground);
+		// Let releases over visible drop indicators fall through to them.
+		setAttribute(Qt::WA_TransparentForMouseEvents);
 	}
-
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    auto Flags = windowFlags();
-    Flags |= Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint;
-    setWindowFlags(Flags);
-#endif
 
 	// Create a static image of the widget that should get undocked
 	// This is like some kind preview image like it is uses in drag and drop
@@ -352,10 +359,20 @@ CFloatingDragPreview::~CFloatingDragPreview()
 //============================================================================
 void CFloatingDragPreview::moveFloating()
 {
-	int BorderSize = (frameSize().width() - size().width()) / 2;
-	const QPoint moveToPos = QCursor::pos() - d->DragStartMousePosition
+	const int BorderSize = (frameSize().width() - size().width()) / 2;
+	const QPoint TargetGlobal = QCursor::pos() - d->DragStartMousePosition
 	    - QPoint(BorderSize, 0);
-	move(moveToPos);
+	// Wayland: when we're a child widget (frameless config), translate
+	// the screen-coord target into parent-local space so move() actually
+	// places us under the cursor.
+	if (isWindow() || !parentWidget())
+	{
+		move(TargetGlobal);
+	}
+	else
+	{
+		move(parentWidget()->mapFromGlobal(TargetGlobal));
+	}
 	d->updateDropOverlays(QCursor::pos());
 }
 
@@ -370,7 +387,7 @@ void CFloatingDragPreview::startFloating(const QPoint &DragStartMousePos,
 	d->DragStartMousePosition = DragStartMousePos;
 	moveFloating();
 	show();
-
+	raise();
 }
 
 


### PR DESCRIPTION
First of all, thanks a lot for your software, I have been using it for years in Plotjuggler :heart: 

While testing it on ubuntu 26.04, i found some problems that this PR is pparently fixing.
Sorry for the AI generated description that follows.

## Summary

Under native Wayland, the drag preview drifts off the cursor and drop indicators render over the wrong dock area. This is because `CFloatingDragPreview`, `CDockOverlay`, and `CDockOverlayCross` are all top-level `Qt::Tool` windows that the client repositions every mouse-move via `move(globalCoords)`. Wayland's `xdg_toplevel` protocol has no client-driven "move to (x,y)" verb — the compositor owns top-level placement — so those `move()` calls are silently lossy.

This PR makes the three widgets *child widgets* of the dock manager's top-level window. Positioning happens inside the parent's surface via `parentWidget()->mapFromGlobal(...)`, which Qt translates correctly on every backend (xcb, Wayland, Windows, macOS).

## Why not just `Qt::ToolTip` (PR #789)?

PR #789 takes a different approach: keep the widgets as top-levels, swap the window flag from `Qt::Tool` to `Qt::ToolTip` so Wayland uses `xdg_popup` (which *is* client-positionable). It's a smaller patch, but the PR author themselves notes on 2025-11-29:

> Floating window can create successfully. But I move the floating window, **the dock overlay cannot work properly** and I have no idea about it.

The overlay positioning issue is the load-bearing visible bug. `Qt::ToolTip` partially helps the floating preview but still leaves the overlay broken. The child-widget approach in this PR addresses both with one architectural decision: stop being top-level when you need parent-relative positioning that always honors client requests.

PR #789 and this PR are mutually exclusive — pick one, not both.

## What this PR changes

`src/FloatingDragPreview.cpp`:
- Constructor: in the frameless config (`!DragPreviewHasWindowFrame`), parent to `parent->window()` and drop the `Qt::Tool | Qt::FramelessWindowHint` flag setup. Add `WA_TransparentForMouseEvents` so a release directly on a visible drop indicator is no longer intercepted by the translucent preview rectangle.
- `moveFloating()`: convert the screen-coord target to parent-local via `mapFromGlobal()` when the widget is a child. The legacy top-level path (`isWindow() || !parentWidget()`) is preserved for `DragPreviewHasWindowFrame=true`.
- `startFloating()`: `raise()` after `show()` so the child preview paints above sibling docks.

`src/DockOverlay.cpp`:
- `CDockOverlay` and `CDockOverlayCross` constructors: parent to `parent->window()`, drop the `Qt::Tool | FramelessWindowHint | WindowStaysOnTopHint | X11BypassWindowManagerHint` block (only meaningful for top-levels), add `WA_TransparentForMouseEvents`.
- `CDockOverlay::showOverlay()`: convert the target's top-left to parent-local before `move()`. `raise()` after `show()`.
- `CDockOverlayCross::updatePosition()`: simplified — both widgets share the same parent now, so the offset math is straightforward. `raise()` after move.
- `CDockOverlayCross::updateOverlayIcons()`: replace `windowHandle()->devicePixelRatio()` with `devicePixelRatioF()`. `windowHandle()` returns nullptr for a child widget and the original code segfaults as soon as the cross attempts to refresh icon DPR after reparenting.

## What this PR does NOT change

- The `DragPreviewHasWindowFrame=true` config (Windows-style framed preview) keeps the original top-level `Qt::Window` path. The cross-platform behavior on Windows is untouched.
- X11 / xcb behavior: still works. The X11-specific `WindowStaysOnTopHint | X11BypassWindowManagerHint` block on `Q_OS_UNIX` was tied to the top-level `Qt::Tool` window; with no top-level there's nothing to bypass.
- The drag state machine (`mousePress` / `mouseMove` / `mouseRelease` flow through `DockAreaTitleBar`, `DockWidgetTab`, etc.) is untouched.
- The drop indicator label widgets (small icons inside the cross) are untouched — they're now children of a child widget that itself works correctly.

## Forecloses two known follow-ups from the #789 thread

- **\"Can't drag widget out of screen with `Qt::ToolTip`\"** (cristianadam, #789): doesn't apply — we're not using `Qt::ToolTip`, and the preview's bounds are intentionally limited to the manager window for now (the typical rearrangement target is inside the app anyway).
- **\"Need to remove `WindowStaysOnTopHint` for Wayland\"** (Wing-summer, #789): doesn't apply — the StaysOnTop hint is only relevant for top-levels, and we're not top-level in this code path.

## Verification

A standalone reproducer is available at `PlotJuggler/PJ4` (https://github.com/PlotJuggler/PJ4/tree/feature/m2-plot-canvas-skeleton/pj_plot_widgets/sandbox/dock_drag_repro). It mirrors a typical ADS embedding (HiddenTitleBar + custom toolbar puppet-forwarding to the title bar) without any extra widgets. Set `PJ_AUTO_DRAG=1` to fire a synthetic press / 8-step move / release sequence on dock A so the test runs without manual cursor input.

Tested under Ubuntu 26.04, Qt 6.8.3:

- `QT_QPA_PLATFORM=xcb`: drag works, identical UX to before this patch.
- `QT_QPA_PLATFORM=wayland` (native): drag works — preview tracks the cursor, drop indicators highlight correctly under the cursor's dock area, releases land on the indicated edge.

## Repo / branch

This PR comes from `PlotJuggler/Qt-Advanced-Docking-System:feature/wayland-fix`, a single commit on top of upstream master `985ff74`. We're carrying it as a submodule pin in our PJ4 application; happy to rebase / split / amend per review feedback.