### PR TITLE
Linux: only raise floating widgets during an active drag

### DIFF
--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -548,16 +548,16 @@ CDockManager::CDockManager(QWidget *parent) :
             return;
         }
 
-        // If the user clicks the main window or drags a floating widget or works with a
-        // modal dialog, then raise the main window, all floating widgets and the focus window
-        // itself to bring it into foreground of any other application.
-        bool raise = qobject_cast<QMainWindow*>(widget)
-            || qobject_cast<ads::CFloatingDockContainer*>(widget);
-        if (auto dialog = qobject_cast<QDialog*>(widget))
-        {
-            raise |= dialog->isModal();
-        }
-        if (!raise)
+        // Only restack windows while a floating dock widget is actively being dragged.
+        // Reacting to ordinary focus changes makes this handler raise() multiple
+        // top-level windows, which can transfer focus and re-emit focusWindowChanged,
+        // re-entering this handler in a self-sustaining loop that never settles -
+        // visible as constant flicker on Linux/X11. Gating on an
+        // active drag breaks that loop: outside a drag we do nothing.
+        const bool draggingActive = std::any_of(
+            d->FloatingWidgets.begin(), d->FloatingWidgets.end(),
+            [](CFloatingDockContainer* fw){ return fw && fw->isDraggingActive(); });
+        if (!draggingActive)
         {
             return;
         }

--- a/src/FloatingDockContainer.cpp
+++ b/src/FloatingDockContainer.cpp
@@ -818,6 +818,12 @@ CDockContainerWidget* CFloatingDockContainer::dockContainer() const
 }
 
 //============================================================================
+bool CFloatingDockContainer::isDraggingActive() const
+{
+	return d->isState(DraggingFloatingWidget);
+}
+
+//============================================================================
 void CFloatingDockContainer::changeEvent(QEvent *event)
 {
 	Super::changeEvent(event);

--- a/src/FloatingDockContainer.h
+++ b/src/FloatingDockContainer.h
@@ -269,6 +269,11 @@ public:
 	 */
 	void finishDropOperation();
 
+	/**
+	 * Returns true while this floating widget is actively being dragged.
+	 */
+	bool isDraggingActive() const;
+
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     /**
 	 * This is a function that responds to FloatingWidgetTitleBar::maximizeRequest()


### PR DESCRIPTION
On Linux/X11 the CDockManager constructor connects a handler to QApplication::focusWindowChanged that, on every focus-window change, calls raise() on the dock manager, on every floating widget, and on the newly focused window. The original intent (#722) was narrower: bring the application and its floating widgets to the foreground only while a floating dock widget is being dragged over another application.

Reacting to *every* focus change makes this a self-sustaining loop. raise() restacks top-level windows, which on X11 can make the window manager move focus, which re-emits focusWindowChanged and re-enters the handler. Because all windows are raised on every pass, the z-order never reaches a stable state, so the windows keep restacking - visible as continuous flicker. It gets worse the more floating widgets exist, since each pass raises more windows and generates more focus transitions. The later QMainWindow/QDialog/CFloatingDockContainer type test only narrows which focus changes start the loop; once started it still runs unbounded (#785).

Fix: gate the entire raise block on a floating widget actually being dragged. Outside a drag the handler now returns immediately and issues no raise() calls, so it can no longer feed itself - no restacking, no flicker. The foreground behaviour during a real drag is unchanged and ends naturally when the drag finishes.

ADS already tracks this state internally
(FloatingDockContainerPrivate::DraggingFloatingWidget); this exposes it through a small public accessor:

  bool CFloatingDockContainer::isDraggingActive() const;

Fixes #785.