### PR TITLE
Lazy creation of CDockWidgetTab to accomodate a factory defined in Python

### DIFF
--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -34,8 +34,6 @@
 #include "DockWidgetTab.h"
 #include "DockWidget.h"
 
-#include <iostream>
-
 #include <QBoxLayout>
 #include <QAction>
 #include <QSplitter>
@@ -387,7 +385,6 @@ CDockWidget::CDockWidget(CDockManager *manager, const QString &title, QWidget* p
 	setWindowTitle(title);
 	setObjectName(title);
 
-	//d->TabWidget = d->componentsFactory()->createDockWidgetTab(this);
 
 	d->ToggleViewAction = new QAction(title, this);
 	d->ToggleViewAction->setCheckable(true);

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -34,6 +34,8 @@
 #include "DockWidgetTab.h"
 #include "DockWidget.h"
 
+#include <iostream>
+
 #include <QBoxLayout>
 #include <QAction>
 #include <QSplitter>
@@ -50,8 +52,6 @@
 #include <QGuiApplication>
 #include <QScreen>
 #include <QWindow>
-
-#include <iostream>
 
 #include "DockContainerWidget.h"
 #include "DockAreaWidget.h"
@@ -384,7 +384,6 @@ CDockWidget::CDockWidget(CDockManager *manager, const QString &title, QWidget* p
 	setLayout(d->Layout);
 	setWindowTitle(title);
 	setObjectName(title);
-
 
 	d->ToggleViewAction = new QAction(title, this);
 	d->ToggleViewAction->setCheckable(true);

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -509,11 +509,11 @@ QWidget* CDockWidget::widget() const
 
 
 //============================================================================
-CDockWidgetTab* CDockWidget::tabWidget()
+CDockWidgetTab* CDockWidget::tabWidget() const
 {
 	if (!d->TabWidget)
 	{
-		d->TabWidget = d->componentsFactory()->createDockWidgetTab(this);
+		d->TabWidget = d->componentsFactory()->createDockWidgetTab(const_cast<CDockWidget*>(this));
 	}
 	return d->TabWidget;
 }
@@ -958,7 +958,7 @@ void CDockWidget::setIcon(const QIcon& Icon)
 
 
 //============================================================================
-QIcon CDockWidget::icon()
+QIcon CDockWidget::icon() const
 {
 	return tabWidget()->icon();
 }

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -53,6 +53,8 @@
 #include <QScreen>
 #include <QWindow>
 
+#include <iostream>
+
 #include "DockContainerWidget.h"
 #include "DockAreaWidget.h"
 #include "DockManager.h"
@@ -385,7 +387,7 @@ CDockWidget::CDockWidget(CDockManager *manager, const QString &title, QWidget* p
 	setWindowTitle(title);
 	setObjectName(title);
 
-	d->TabWidget = d->componentsFactory()->createDockWidgetTab(this);
+	//d->TabWidget = d->componentsFactory()->createDockWidgetTab(this);
 
 	d->ToggleViewAction = new QAction(title, this);
 	d->ToggleViewAction->setCheckable(true);
@@ -513,6 +515,10 @@ QWidget* CDockWidget::widget() const
 //============================================================================
 CDockWidgetTab* CDockWidget::tabWidget() const
 {
+	if (!d->TabWidget)
+	{
+		d->TabWidget = d->componentsFactory()->createDockWidgetTab(const_cast<CDockWidget*>(this));
+	}
 	return d->TabWidget;
 }
 
@@ -545,7 +551,7 @@ void CDockWidget::setFeatures(DockWidgetFeatures features)
 void CDockWidget::notifyFeaturesChanged()
 {
 	Q_EMIT featuresChanged(d->Features);
-	d->TabWidget->onDockWidgetFeaturesChanged();
+	tabWidget()->onDockWidgetFeaturesChanged();
 	if(CDockAreaWidget* DockArea = dockAreaWidget())
 	{
 		DockArea->onDockWidgetFeaturesChanged();
@@ -724,7 +730,7 @@ void CDockWidget::setToggleViewActionMode(eToggleViewActionMode Mode)
 	else
 	{
 		d->ToggleViewAction->setCheckable(false);
-		d->ToggleViewAction->setIcon(d->TabWidget->icon());
+		d->ToggleViewAction->setIcon(tabWidget()->icon());
 	}
 }
 
@@ -941,7 +947,7 @@ void CDockWidget::setTabToolTip(const QString &text)
 //============================================================================
 void CDockWidget::setIcon(const QIcon& Icon)
 {
-	d->TabWidget->setIcon(Icon);
+	tabWidget()->setIcon(Icon);
 
 	if (d->SideTabWidget)
 	{
@@ -958,7 +964,7 @@ void CDockWidget::setIcon(const QIcon& Icon)
 //============================================================================
 QIcon CDockWidget::icon() const
 {
-	return d->TabWidget->icon();
+	return tabWidget()->icon();
 }
 
 
@@ -1141,7 +1147,7 @@ void CDockWidget::setFloating()
 	}
 	else
 	{
-		d->TabWidget->detachDockWidget();
+		tabWidget()->detachDockWidget();
 	}
 }
 

--- a/src/DockWidget.cpp
+++ b/src/DockWidget.cpp
@@ -509,11 +509,11 @@ QWidget* CDockWidget::widget() const
 
 
 //============================================================================
-CDockWidgetTab* CDockWidget::tabWidget() const
+CDockWidgetTab* CDockWidget::tabWidget()
 {
 	if (!d->TabWidget)
 	{
-		d->TabWidget = d->componentsFactory()->createDockWidgetTab(const_cast<CDockWidget*>(this));
+		d->TabWidget = d->componentsFactory()->createDockWidgetTab(this);
 	}
 	return d->TabWidget;
 }
@@ -958,7 +958,7 @@ void CDockWidget::setIcon(const QIcon& Icon)
 
 
 //============================================================================
-QIcon CDockWidget::icon() const
+QIcon CDockWidget::icon()
 {
 	return tabWidget()->icon();
 }

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -341,9 +341,9 @@ public:
 
     /**
      * Returns the tab widget of this dock widget that is shown in the dock
-     * area title bar
+     * area title bar. Create it if needed
      */
-    CDockWidgetTab* tabWidget() const;
+    CDockWidgetTab* tabWidget();
 
     /**
      * Sets, whether the dock widget is movable, closable, and floatable.
@@ -502,7 +502,7 @@ public:
     /**
      * Returns the icon that has been assigned to the dock widget
      */
-    QIcon icon() const;
+    QIcon icon();
 
     /**
      * This function returns the dock widget top tool bar.

--- a/src/DockWidget.h
+++ b/src/DockWidget.h
@@ -341,9 +341,9 @@ public:
 
     /**
      * Returns the tab widget of this dock widget that is shown in the dock
-     * area title bar. Create it if needed
+     * area title bar
      */
-    CDockWidgetTab* tabWidget();
+    CDockWidgetTab* tabWidget() const;
 
     /**
      * Sets, whether the dock widget is movable, closable, and floatable.
@@ -502,7 +502,7 @@ public:
     /**
      * Returns the icon that has been assigned to the dock widget
      */
-    QIcon icon();
+    QIcon icon() const;
 
     /**
      * This function returns the dock widget top tool bar.


### PR DESCRIPTION
Would fix #847 
I tested the MREs referred to in the issue
I also ran my app (Scrutiny Debugger) with the fixed version and it behaves well.