### PR TITLE
Make Auto Hide Side Bar React Correctly To Scroll Events

### DIFF
--- a/src/AutoHideSideBar.cpp
+++ b/src/AutoHideSideBar.cpp
@@ -34,6 +34,7 @@
 #include <QStyleOption>
 #include <QPainter>
 #include <QXmlStreamWriter>
+#include <QWheelEvent>
 
 #include "DockContainerWidget.h"
 #include "DockWidgetTab.h"
@@ -300,6 +301,13 @@ bool CAutoHideSideBar::eventFilter(QObject *watched, QEvent *event)
 		 }
 		 break;
 
+#if QT_CONFIG(wheelevent)
+	case QEvent::Wheel:
+		// the button received the event so pass to the scroll area
+		wheelEvent(static_cast<QWheelEvent*>(event));
+		break;
+#endif
+
 	default:
 		break;
 	}
@@ -431,6 +439,41 @@ QSize CAutoHideSideBar::sizeHint() const
 {
 	return d->TabsContainerWidget->sizeHint();
 }
+
+
+//===========================================================================
+#if QT_CONFIG(wheelevent)
+void CAutoHideSideBar::wheelEvent(QWheelEvent* e)
+{
+	QPoint AngleDelta = e->angleDelta();
+
+	// completely ignore the effects if the alt key is being held
+	// if alt is held on a vertical scroll area, cancel the applied horizontal scroll by forcing a vertical scroll
+	// if alt is held on a horizontal scroll area, cancel the applied vertical scroll by forcing a horizontal scroll
+	if (!d->isHorizontal() && (e->modifiers() & Qt::KeyboardModifier::AltModifier) ||
+		 d->isHorizontal() && (~e->modifiers() & Qt::KeyboardModifier::AltModifier))
+	{
+		AngleDelta = e->angleDelta().transposed();
+	}
+
+	QWheelEvent WheelEvent {
+		e->position(),
+		e->globalPosition(),
+		e->pixelDelta(),
+		AngleDelta,
+		e->buttons(),
+		e->modifiers(),
+		e->phase(),
+		e->inverted(),
+		e->source()
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+		,e->pointingDevice()
+#endif
+	};
+
+	Super::wheelEvent(&WheelEvent);
+}
+#endif
 
 
 //===========================================================================

--- a/src/AutoHideSideBar.h
+++ b/src/AutoHideSideBar.h
@@ -185,6 +185,16 @@ public:
 	 */
 	virtual QSize sizeHint() const override;
 
+#if QT_CONFIG(wheelevent)
+	/**
+	 * This function handles scroll wheel events and will ignore the
+	 * alt key modifier if applied by the user to make sure vertical
+	 * auto-hide side bars will always scroll vertically and that
+	 * horizontal ones will always scroll horizontally.
+	 */
+	virtual void wheelEvent(QWheelEvent* e) override;
+#endif
+
 	/**
 	 * Getter for spacing property - returns the spacing of the tabs
 	 */


### PR DESCRIPTION
- the scroll wheel operation only worked between the tabbed buttons and not when the mouse was on the auto hide tab button.  since the auto hide side bar already had event filters applied to the auto hide tab buttons, a filtered event of the mouse wheel is redirected to be handled by the auto hide side bar class itself.

- the auto hide side bar class now handles the wheel event to correctly handle the direction the auto scroll should take.  previously, when the scroll operation was performed on a vertical auto hide side bar, the scroll operation with no keyboard modifiers would scroll vertically as expected.  when a scroll operation was performed on a horizontal auto hide side bar, the scroll operation would still move the viewport vertically.  this change now detects the orientation of the auto hide side bar to correctly apply the mouse wheel operation.

- the alt key will no longer have any effect.  when the alt key was held during the scroll operation, the opposite scroll operation was performed.  if alt is detected, the x and y angle deltas are just swapped to perform the correct scroll operation.

- validated the following combinations:
  * Windows 11 Qt6 x86_64
  * Windows 11 Qt5 x86_64
  * Kubuntu 25.10 Qt6 Wayland x86_64