### PR TITLE
Build With Multiple Processes When MSVC Is Detected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ else()
     set(ads_PlatformDir "${ADS_PLATFORM_DIR}")
 endif()
 
+if(QtADS_IS_TOP_LEVEL)
+   add_compile_options($<${MSVC}:/MP>)
+endif()
+
 add_subdirectory(src)
 
 if(BUILD_EXAMPLES)


### PR DESCRIPTION
- add the /MP option to the command line to help decrease compilation times.  this will only impact solutions that target visual studio. this compile option will only be added to the command line if QtADS is the main project detected; otherwise, it is assumed that QtADS is being sourced as an external 3rd party library to a larger compilation solution that defines its own compilation requirements.

- debug full rebuild of all projects without /MP built 80 seconds.  same rebuild with /MP built in 20 seconds.