### PR TITLE
fix use-after-free in updateTabs queued call

### DIFF
--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -37,6 +37,7 @@
 #include <QApplication>
 #include <QtGlobal>
 #include <QTimer>
+#include <QPointer>
 
 #include "FloatingDockContainer.h"
 #include "DockAreaWidget.h"
@@ -111,9 +112,11 @@ void DockAreaTabBarPrivate::updateTabs()
 			// Sometimes the synchronous calculation of the rectangular area fails
 			// Therefore we use QTimer::singleShot here to execute the call
 			// within the event loop - see #520
-			QTimer::singleShot(0, _this, [&, TabWidget]
-			{
-				_this->ensureWidgetVisible(TabWidget);
+			// The tab may be destroyed with the layout before this queued call runs.
+			QTimer::singleShot(0, _this, [this, TabWidget = QPointer<CDockWidgetTab>(TabWidget)] {
+				if (TabWidget) {
+					_this->ensureWidgetVisible(TabWidget);
+				}
 			});
 		}
 		else


### PR DESCRIPTION
The tab may be destroyed with the layout before the queued ensureWidgetVisible runs; guard it with QPointer and skip if gone.