### PR TITLE
Add CMake Code To Group Projects To Folders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,12 @@ endif()
 
 project(QtADS LANGUAGES CXX VERSION ${VERSION_SHORT})
 
+if(CMAKE_VERSION VERSION_LESS 3.21.0)
+    if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+        set(QtADS_IS_TOP_LEVEL true)
+    endif()
+endif()
+
 option(BUILD_STATIC "Build the static library" OFF)
 option(BUILD_EXAMPLES "Build the examples" ON)
 
@@ -50,6 +56,12 @@ if(NOT ADS_PLATFORM_DIR)
     endif()
 else()
     set(ads_PlatformDir "${ADS_PLATFORM_DIR}")
+endif()
+
+if(QtADS_IS_TOP_LEVEL)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.26.0)
+        cmake_policy(SET CMP0143 NEW)
+    endif()
 endif()
 
 add_subdirectory(src)

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(ads_demo VERSION ${VERSION_SHORT}) 
 
+if(QtADS_IS_TOP_LEVEL)
+    set(CMAKE_FOLDER "Demo")
+endif()
+
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets Quick QuickWidgets REQUIRED)
 if(WIN32 AND QT_VERSION_MAJOR LESS 6)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(QtADSExamples LANGUAGES CXX VERSION ${VERSION_SHORT})
+
+if(QtADS_IS_TOP_LEVEL)
+    set(CMAKE_FOLDER "Examples")
+endif()
+
 add_subdirectory(simple)
 add_subdirectory(hideshow)
 add_subdirectory(sidebar)


### PR DESCRIPTION
- this change groups the different projects to folders in supported generators that correspond to an ide.

this change groups the different projects to folders to keep the ide solution clean and tidy.  this change will only be applied if qt ads is being generated as a standalone solution.

<img width="595" height="772" alt="image" src="https://github.com/user-attachments/assets/47b3fab0-ee32-4787-b890-b91407af95ec" />
