### PR TITLE
Make restoreState restore the focused dock widget

### DIFF
--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -123,6 +123,7 @@ struct DockManagerPrivate
 	bool RestoringState = false;
 	QVector<CFloatingDockContainer*> UninitializedFloatingWidgets;
 	CDockFocusController* FocusController = nullptr;
+	QString RestoredFocusedDockWidget;
     CDockWidget* CentralWidget = nullptr;
     bool IsLeavingMinimized = false;
 	Qt::ToolButtonStyle ToolBarStyleDocked = Qt::ToolButtonIconOnly;
@@ -335,6 +336,12 @@ bool DockManagerPrivate::restoreStateFromXml(const QByteArray &state,  int versi
 			return false;
 		}
     }
+
+	if (!Testing)
+	{
+		// Store the saved focused dock widget name so it can be reapplied after stale focus styling is cleared.
+		RestoredFocusedDockWidget = s.attributes().value("FocusedDockWidget").toString();
+	}
 
     int DockContainerCount = 0;
     while (s.readNextStartElement())
@@ -871,6 +878,10 @@ QByteArray CDockManager::saveState(int version) const
 		{
 			s.writeAttribute("CentralWidget", d->CentralWidget->objectName());
 		}
+		if (auto FocusedDockWidget = focusedDockWidget())
+		{
+			s.writeAttribute("FocusedDockWidget", FocusedDockWidget->objectName());
+		}
 		for (auto Container : d->Containers)
 		{
 			Container->saveState(s);
@@ -916,6 +927,13 @@ bool CDockManager::restoreState(const QByteArray &state, int version)
 		show();
 	}
 	Q_EMIT stateRestored();
+	if (Result && !d->RestoredFocusedDockWidget.isEmpty())
+	{
+		if (auto DockWidget = findDockWidget(d->RestoredFocusedDockWidget))
+		{
+			setDockWidgetFocused(DockWidget);
+		}
+	}
 	return Result;
 }
 


### PR DESCRIPTION
Fixes #852

`saveState()` / `restoreState()` preserved the layout and each area's current tab, but not the globally focused dock widget, so the focused split area was lost after restoring state.

Changes:

- Save the focused dock widget's `objectName()` in the docking state.
- Restore that focus after the normal state restoration completes.


### Before

<img width="800" height="517" alt="before" src="https://github.com/user-attachments/assets/0275463b-6a5b-4700-b90c-3831798eb31b" />

### After

<img width="800" height="517" alt="after" src="https://github.com/user-attachments/assets/eb86d011-23dc-499a-9bf7-e7613b610b0f" />
