### PR TITLE
Fix discard and deprecation warnings

### DIFF
--- a/demo/MainWindow.cpp
+++ b/demo/MainWindow.cpp
@@ -1010,10 +1010,13 @@ void CMainWindow::toggleDockWidgetWindowTitle()
 void CMainWindow::applyVsStyle()
 {
 	QFile StyleSheetFile(":adsdemo/res/visual_studio_light.css");
-	StyleSheetFile.open(QIODevice::ReadOnly);
-	QTextStream StyleSheetStream(&StyleSheetFile);
-	auto Stylesheet = StyleSheetStream.readAll();
-	StyleSheetFile.close();
+	QString Stylesheet;
+	if (StyleSheetFile.open(QIODevice::ReadOnly))
+	{
+		QTextStream StyleSheetStream(&StyleSheetFile);
+		Stylesheet = StyleSheetStream.readAll();
+		StyleSheetFile.close();
+	}
 	d->DockManager->setStyleSheet(Stylesheet);
 }
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -55,9 +55,11 @@ int main(int argc, char *argv[])
 	mw.show();
 
 	QFile StyleSheetFile(":/adsdemo/app.css");
-	StyleSheetFile.open(QIODevice::ReadOnly);
-	QTextStream StyleSheetStream(&StyleSheetFile);
-	a.setStyleSheet(StyleSheetStream.readAll());
-	StyleSheetFile.close();
+	if (StyleSheetFile.open(QIODevice::ReadOnly))
+	{
+		QTextStream StyleSheetStream(&StyleSheetFile);
+		a.setStyleSheet(StyleSheetStream.readAll());
+		StyleSheetFile.close();
+	}
 	return a.exec();
 }

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -751,7 +751,7 @@ bool CDockManager::eventFilter(QObject *obj, QEvent *e)
 		}
 		if (!window()->isMinimized())
 		{
-			QApplication::setActiveWindow(window());
+			window()->activateWindow();
 		}
 	}
 #else

--- a/src/DockManager.cpp
+++ b/src/DockManager.cpp
@@ -227,10 +227,12 @@ void DockManagerPrivate::loadStylesheet()
         CurrentStylesheetDark = false;
     FileName += ".css";
 	QFile StyleSheetFile(FileName);
-	StyleSheetFile.open(QIODevice::ReadOnly);
-	QTextStream StyleSheetStream(&StyleSheetFile);
-	Result = StyleSheetStream.readAll();
-	StyleSheetFile.close();
+	if (StyleSheetFile.open(QIODevice::ReadOnly))
+	{
+		QTextStream StyleSheetStream(&StyleSheetFile);
+		Result = StyleSheetStream.readAll();
+		StyleSheetFile.close();
+	}
 	_this->setStyleSheet(Result);
 }
 


### PR DESCRIPTION
  ## Fix compiler warnings with GCC 15 / Qt 6.10

  Building the library and demo with GCC 15.2 and Qt 6.10.2 produces a few warnings. This PR fixes them in two small commits.

  **Check return value of `QFile::open` when loading stylesheets**
  `QFile::open` is marked `nodiscard` in Qt 6, so ignoring its result triggers `-Wunused-result`. The stylesheet loading in
  `CDockManager`, the demo's `main.cpp` and `CMainWindow::applyVsStyle` now only read the file when it was opened successfully. Behaviour
  is unchanged: a missing file still results in an empty stylesheet.

  **Replace deprecated `QApplication::setActiveWindow` with `QWidget::activateWindow`**
  `QApplication::setActiveWindow` is deprecated since Qt 6.5 and triggers `-Wdeprecated-declarations`. `QWidget::activateWindow` is the
  recommended replacement and is available in both Qt 5 and Qt 6, so no version guard is needed.

  After these changes the library, all examples and the demo build without warnings, also with `-Wall -Wextra`.